### PR TITLE
debian-11 packaging: disable debian_nogroup_for_sample_files.patch

### DIFF
--- a/buildbot-host/buildmaster/debian/debian-11/debian/patches/series
+++ b/buildbot-host/buildmaster/debian/debian-11/debian/patches/series
@@ -1,6 +1,6 @@
 move_log_dir.patch
 auth-pam_libpam_so_filename.patch
-debian_nogroup_for_sample_files.patch
+#debian_nogroup_for_sample_files.patch
 openvpn-pkcs11warn.patch
 #kfreebsd_support.patch
 #match-manpage-and-command-help.patch


### PR DESCRIPTION
Invalidated by commit a6664825494c482e0cbf50ac4a91c6a33874d7a7 in OpenVPN/openvpn.

Signed-off-by: Frank Lichtenheld <frank@lichtenheld.com>