### PR TITLE
msibuilder.ps1: Fix WiX download

### DIFF
--- a/scripts/msibuilder.ps1
+++ b/scripts/msibuilder.ps1
@@ -1,16 +1,14 @@
 Write-Host "Installing dependencies for building MSI packages"
 
+. $PSScriptRoot\ps_support.ps1
+
 # Chocolatey package bundles WiX version too old for building ARM64 MSIs.
 #& choco.exe install -y wixtoolset
 
-# Invoke-Webrequest seems to exit before the installer has been completely
-# downloaded, resulting in a silent WiX installation failure. Therefore we
-# wrap it into a Job to ensure that the installer has downloaded before
-# attempting to run it.
-Start-Job -Name "GetWiX" -ScriptBlock { Invoke-WebRequest -Uri https://wixtoolset.org/downloads/v3.14.0.4118/wix314.exe -Outfile "C:\Windows\Temp\wix314.exe" }
-Wait-Job -Name "GetWiX"
+Invoke-WebRequest -Uri "https://build.openvpn.net/downloads/temp/wix314.exe" -Outfile "C:\Windows\Temp\wix314.exe"
 
 & "C:\Windows\Temp\wix314.exe" /q
+CheckLastExitCode
 
 # Add WiX tools to PATH. Adapted from https://www.yudhistiramauris.com/add-new-entry-to-path-variable-permanently-using-windows-powershell
 $wixpath = "C:\Program Files (x86)\WiX Toolset v3.14\bin"


### PR DESCRIPTION
Use our own copy of wix314.exe since the official download servers have been down for days.

Remove the weird Start-Job work-around while here. For reasons I do not understand, it suddenly broke for me. But the failure occured only when running it via packer and only on first run, not when retrying the step. Weird stuff. Anyway, replace the work-around by checking the return code of the installation to make sure it can't fail silently.

Signed-off-by: Frank Lichtenheld <frank@lichtenheld.com>