### PR TITLE
buildmaster: add new option openvpn_extra_config_opts

### DIFF
--- a/buildbot-host/buildmaster/Dockerfile
+++ b/buildbot-host/buildmaster/Dockerfile
@@ -1,5 +1,5 @@
 ARG MY_NAME="buildmaster"
-ARG MY_VERSION="v2.2.0"
+ARG MY_VERSION="v2.2.1"
 ARG IMAGE=buildbot/buildbot-master:v3.5.0
 
 FROM $IMAGE

--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -315,6 +315,10 @@ for factory_name, factory in factories.items():
       #
       properties = {}
 
+      o = worker_config.get(worker_name, "openvpn_extra_config_opts")
+      if o.startswith("--"):
+        properties['openvpn_extra_config_opts'] = o
+
       o = worker_config.get(worker_name, "openvpn3_linux_extra_config_opts")
       if o.startswith("--"):
         properties['openvpn3_linux_extra_config_opts'] = o

--- a/buildbot-host/buildmaster/openvpn/common_unix_steps.cfg
+++ b/buildbot-host/buildmaster/openvpn/common_unix_steps.cfg
@@ -12,7 +12,7 @@ def openvpnAddCommonUnixStepsToBuildFactory(factory, combo):
                                         description="reconfiguring",
                                         descriptionDone="reconfiguring"))
 
-    configure = ["./configure"] + combo.split(" ")
+    configure = ["./configure"] + combo.split(" ") + [util.Interpolate('%(prop:openvpn_extra_config_opts)s')]
 
     factory.addStep(steps.ShellCommand(command=configure,
                                         name="configure",

--- a/buildbot-host/buildmaster/worker-default.ini
+++ b/buildbot-host/buildmaster/worker-default.ini
@@ -15,6 +15,7 @@ enable_openvpn3-linux_builds=true
 enable_ovpn-dco_builds=true
 
 # Build options
+openvpn_extra_config_opts=
 openvpn3_linux_extra_config_opts=
 openvpn3_linux_command_prefix=["/bin/sh", "-c"]
 
@@ -24,13 +25,20 @@ openvpn3_linux_command_prefix=["/bin/sh", "--login", "-c"]
 openvpn3_linux_extra_config_opts=--disable-unit-tests
 # asio in CentOS 7 is too old to work with openvpn3
 enable_openvpn3_builds=false
+enable_ovpn-dco_builds=false
+openvpn_extra_config_opts=--disable-dco
+enable_debian_builds=false
 
 [debian-10]
 image=openvpn_community/buildbot-worker-debian-10:v1.0.1
 enable_ovpn-dco_builds=false
+openvpn_extra_config_opts=--disable-dco
+# xxhash too old
+enable_openvpn3_builds=false
 
 [debian-11]
 image=openvpn_community/buildbot-worker-debian-11:v1.0.1
+password=TZWH1pC1icD9VbSyil3u
 
 [debian-unstable]
 image=openvpn_community/buildbot-worker-debian-unstable:v1.0.1
@@ -66,18 +74,22 @@ image=openvpn_community/buildbot-worker-opensuse-leap-15:v1.0.1
 enable_debian_builds=false
 # Kernel headers are not usable on this platform out of the box
 enable_ovpn-dco_builds=false
+openvpn_extra_config_opts=--disable-dco
 
 [ubuntu-1804]
 image=openvpn_community/buildbot-worker-ubuntu-1804:v1.0.1
 enable_mbedtls_builds=false
 enable_ovpn-dco_builds=false
+openvpn_extra_config_opts=--disable-dco
+# asio too old
+enable_openvpn3_builds=false
 
 [ubuntu-2004]
 image=openvpn_community/buildbot-worker-ubuntu-2004:v1.0.1
 
-[ubuntu-2004-vm-static]
-type=normal
-ostype=unix
+#[ubuntu-2004-vm-static]
+#type=normal
+#ostype=unix
 
 [ubuntu-2204]
 image=openvpn_community/buildbot-worker-ubuntu-2204:v1.0.0
@@ -85,22 +97,9 @@ image=openvpn_community/buildbot-worker-ubuntu-2204:v1.0.0
 [ubuntu-2210]
 image=openvpn_community/buildbot-worker-ubuntu-2210:v1.0.0
 
-[windows-server-2019-static]
-type=normal
-ostype=windows
-signing_cert_sha1=E66F92739E4DAB465846EB9DEAF242ACA6E86624
-signing_cert_password=foobar
-timestamp_url=http://timestamp.digicert.com
-
-[windows-server-2019-latent-ec2]
-type=normal
-ostype=windows
-signing_cert_sha1=E66F92739E4DAB465846EB9DEAF242ACA6E86624
-signing_cert_password=foobar
-timestamp_url=http://timestamp.digicert.com
-
-#[macosx-amd64]
-#home=/Users/buildbot
-
-#[openbsd-49-i386]
-#extra_build_flags=["--disable-plugin-auth-pam"]
+#[windows-server-2019-latent-ec2]
+#type=normal
+#ostype=windows
+#signing_cert_sha1=029F2B420F1CA580FA90101AABEF3AFF96AE9076
+#signing_cert_password=4jgAvGaIIda391j2w
+#timestamp_url=http://timestamp.digicert.com


### PR DESCRIPTION
We use this to pass --disable-dco to builds that need it when we will enable it by default.