### PR TITLE
buildmaster: Add "persist" property to workers

### DIFF
--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -104,17 +104,21 @@ c['workers'] = []
 
 # Create normal and latent workers
 for worker_name in worker_names:
+    worker_persist = worker_config.get(worker_name, "persist")
     if worker_config.get(worker_name, "type") ==  "latent_docker":
       image = worker_config.get(worker_name, "image")
       c['workers'].append(worker.DockerLatentWorker(worker_name,
                                                     worker_config.get(worker_name, "password"),
                                                     max_builds=1,
                                                     notify_on_missing=notify_on_missing,
+                                                    properties = {
+                                                        "persist": worker_persist,
+                                                    },
                                                     docker_host=docker_host,
                                                     followStartupLogs=True,
                                                     image=image,
                                                     masterFQDN="buildmaster",
-                                                    volumes=[f'buildbot-worker-{worker_name}:/home/buildbot'],
+                                                    volumes=[f'buildbot-worker-{worker_name}:{worker_persist}'],
                                                     hostconfig = { "network_mode": docker_network,
                                                                    "sysctls": { "net.ipv6.conf.all.disable_ipv6": 0 },
                                                                    "cap_add": ["NET_ADMIN"] }))
@@ -123,7 +127,13 @@ for worker_name in worker_names:
                             worker_config.get(worker_name, "password"),
                             max_builds=1,
                             notify_on_missing=notify_on_missing,
-                            properties = { 'signing_cert_password': get_worker_setting(worker_config, worker_name, 'signing_cert_password'), 'signing_cert_sha1': get_worker_setting(worker_config, worker_name, 'signing_cert_sha1'), 'timestamp_url': get_worker_setting(worker_config, worker_name, 'timestamp_url')}))
+                            properties = {
+                                "persist": worker_persist,
+                                'signing_cert_password': get_worker_setting(worker_config, worker_name, 'signing_cert_password'),
+                                'signing_cert_sha1': get_worker_setting(worker_config, worker_name, 'signing_cert_sha1'),
+                                'timestamp_url': get_worker_setting(worker_config, worker_name, 'timestamp_url')
+                            }
+        ))
 
 c['protocols'] = {'pb': {'port': r"tcp:interface=\:\:0:port=9989"}}
 
@@ -212,8 +222,8 @@ for steps_file in ["common_linux_steps.cfg"]:
     exec(compile(source=open(os.path.join('ovpn-dco', steps_file)).read(), filename=os.path.join('ovpn-dco', steps_file), mode='exec'))
 
 ccache = {
-    'PATH': ['/usr/lib64/ccache', '/usr/lib/ccache/bin', '/usr/lib/ccache', "${PATH}"],
-    'CCACHE_DIR': '/home/buildbot/ccache',
+    'PATH': ['/usr/local/opt/ccache/libexec', '/usr/lib64/ccache', '/usr/lib/ccache/bin', '/usr/lib/ccache', "${PATH}"],
+    'CCACHE_DIR': util.Interpolate('%(prop:persist)s/ccache'),
     'CCACHE_MAXSIZE': '1Gi',
 }
 

--- a/buildbot-host/buildmaster/openvpn/tclient_steps.cfg
+++ b/buildbot-host/buildmaster/openvpn/tclient_steps.cfg
@@ -19,7 +19,7 @@ def openvpnAddTClientStepsToBuildFactory(factory, combo, shell_env=None):
 
 
     # These steps restore a cached t_client_ips.rc, if any. On the first run it won't exist.
-    factory.addStep(steps.ShellCommand(command=["cp", "-vf",  "/home/buildbot/t_client_ips.rc", "."],
+    factory.addStep(steps.ShellCommand(command=["cp", "-vf", util.Interpolate('%(prop:persist)s/t_client_ips.rc'), "."],
                                         name="restore t_client_ips.rc",
                                         decodeRC={0:SUCCESS,1:SUCCESS},
                                         description="restoring",
@@ -51,7 +51,7 @@ def openvpnAddTClientStepsToBuildFactory(factory, combo, shell_env=None):
                                         descriptionDone="testing"))
 
     # Copy the current t_client_ips.rc out of the build directory to restore it later.
-    factory.addStep(steps.ShellCommand(command=["cp", "-vf", "t_client_ips.rc", "/home/buildbot/t_client_ips.rc"],
+    factory.addStep(steps.ShellCommand(command=["cp", "-vf", "t_client_ips.rc", util.Interpolate('%(prop:persist)s/t_client_ips.rc')],
                                         name="cache t_client_ips.rc",
                                         description="caching",
                                         descriptionDone="caching"))

--- a/buildbot-host/buildmaster/worker-default.ini
+++ b/buildbot-host/buildmaster/worker-default.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-home=/home/buildbot
+persist=/home/buildbot
 extra_build_flags=""
 type=latent_docker
 ostype=unix
@@ -83,6 +83,13 @@ image=openvpn_community/buildbot-worker-ubuntu-2204:v1.0.0
 
 [ubuntu-2210]
 image=openvpn_community/buildbot-worker-ubuntu-2210:v1.0.0
+
+#[macos-amd64]
+#type=normal
+#persist=/Users/buildbot
+#enable_debian_builds=false
+#enable_openvpn3-linux_builds=false
+#enable_ovpn-dco_builds=false
 
 #[windows-server-2019-latent-ec2]
 #type=normal


### PR DESCRIPTION
This is a directory where buildbot can save data and caches that will be persisted to the next build.

This fixes issues with caching on the macOS workers.