### PR TITLE
Update workers for Ubuntu 23.04 and Fedora 38 releases

### DIFF
--- a/buildbot-host/buildbot-worker-fedora-38/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-fedora-38/Dockerfile.base
@@ -1,5 +1,5 @@
-ARG IMAGE=fedora:36
+ARG IMAGE=fedora:38
 ARG DEPS_SH=install-openvpn-build-deps-fedora.sh
-ARG MY_NAME="buildbot-worker-fedora-36"
+ARG MY_NAME="buildbot-worker-fedora-38"
 ARG MY_VERSION="v1.0.0"
 ARG ASIO_REF="asio-1-18-2"

--- a/buildbot-host/buildbot-worker-fedora-38/env
+++ b/buildbot-host/buildbot-worker-fedora-38/env
@@ -1,3 +1,3 @@
 BUILDMASTER=buildmaster
-WORKERNAME=fedora-36
+WORKERNAME=fedora-38
 WORKERPASS=vagrant

--- a/buildbot-host/buildbot-worker-ubuntu-2210/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-ubuntu-2210/Dockerfile.base
@@ -1,5 +1,0 @@
-ARG IMAGE=ubuntu:22.10
-ARG DEPS_SH=install-openvpn-build-deps-ubuntu.sh
-ARG MY_NAME="buildbot-worker-ubuntu-2210"
-ARG MY_VERSION="v1.0.0"
-ARG ASIO_REF="asio-1-18-2"

--- a/buildbot-host/buildbot-worker-ubuntu-2304/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-ubuntu-2304/Dockerfile.base
@@ -1,0 +1,6 @@
+ARG IMAGE=ubuntu:23.04
+ARG DEPS_SH=install-openvpn-build-deps-ubuntu.sh
+ARG MY_NAME="buildbot-worker-ubuntu-2304"
+ARG PIP_INSTALL_OPTS="--break-system-packages"
+ARG MY_VERSION="v1.0.0"
+ARG ASIO_REF="asio-1-18-2"

--- a/buildbot-host/buildbot-worker-ubuntu-2304/env
+++ b/buildbot-host/buildbot-worker-ubuntu-2304/env
@@ -1,3 +1,3 @@
 BUILDMASTER=buildmaster
-WORKERNAME=ubuntu-2110
+WORKERNAME=ubuntu-2304
 WORKERPASS=vagrant

--- a/buildbot-host/buildmaster/worker-default.ini
+++ b/buildbot-host/buildmaster/worker-default.ini
@@ -52,12 +52,12 @@ enable_debian_builds=false
 enable_openvpn3_builds=false
 enable_openvpn3-linux_builds=false
 
-[fedora-36]
-image=openvpn_community/buildbot-worker-fedora-36:v1.0.0
-enable_debian_builds=false
-
 [fedora-37]
 image=openvpn_community/buildbot-worker-fedora-37:v1.0.0
+enable_debian_builds=false
+
+[fedora-38]
+image=openvpn_community/buildbot-worker-fedora-38:v1.0.0
 enable_debian_builds=false
 
 #[fedora-rawhide]
@@ -81,8 +81,8 @@ image=openvpn_community/buildbot-worker-ubuntu-2004:v1.0.1
 [ubuntu-2204]
 image=openvpn_community/buildbot-worker-ubuntu-2204:v1.0.0
 
-[ubuntu-2210]
-image=openvpn_community/buildbot-worker-ubuntu-2210:v1.0.0
+[ubuntu-2304]
+image=openvpn_community/buildbot-worker-ubuntu-2304:v1.0.0
 
 #[macos-amd64]
 #type=normal


### PR DESCRIPTION
Replace Ubuntu 22.10 with Ubuntu 23.04 (only build latest non-LTS release)
Replace Fedora 36 with Fedora 38 (always build two latest Fedora releases)