### PR TITLE
Fix BuildBot branch filter for Gerrit

### DIFF
--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -513,10 +513,10 @@ c['schedulers'].append(schedulers.SingleBranchScheduler(
 
 c['schedulers'].append(schedulers.SingleBranchScheduler(
                         name="openvpn-gerrit",
-                        change_filter=util.ChangeFilter(filter_fn = lambda c: c.properties.getProperty('event.patchSet.uploader.name') in verified_authors_list,
-							repository_re = '.*gerrit.*',
-							branch = openvpn_branch,
-							project = 'openvpn'),
+                        change_filter=util.ChangeFilter(filter_fn = lambda c: c.properties.getProperty('event.patchSet.uploader.name') in verified_authors_list and
+                                                                              c.properties.getProperty('target_branch') in openvpn_branch,
+                                                        repository_re = '.*gerrit.*',
+                                                        project = 'openvpn'),
                         treeStableTimer=openvpn_tree_stable_timer,
                         builderNames=builder_names['openvpn']))
 


### PR DESCRIPTION
Gerrit uses it's own 'target_branch' name