### PR TITLE
Provisioning fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This system has been tested on:
 * Vagrant + Virtualbox Windows 10
 * Vagrant + Hyper-V on Windows 10
 * Amazon EC2 Ubuntu 20.04 server instance (t3a.large)
+* Amazon EC2 Ubuntu 22.04 server instance (t3a.large)
+* Amazon EC2 Ubuntu 23.10 server instance (t3a.large)
 
 The whole system is configured to use 8GB of memory. However, it could potentially run in less, because
 all the buildbot workers that do the heavy lifting are latent Docker and EC2 workers. 

--- a/README.md
+++ b/README.md
@@ -100,8 +100,31 @@ Then provision the environment:
 
     /full/path/to/buildbot-host/provision.sh
 
+The provisioning script will create dummy t_client and Authenticode
+certificates. This step is required to succesfully build buildbot worker and
+master container images. These dummy certificates will suffice unless you are
+going to run t_client tests or do Windows code signing.
+
 Note that provisioning is only tested on Ubuntu 20.04 server and is unlikely to
 work on any other Ubuntu or Debian version without modifications.
+
+After provisioning you need to create a suitable *master.ini* file based on
+*master-default.ini*. In general two changes should be made:
+
+* Ensure that email address are valid or buildmaster will fail to start
+* Ensure that repository URLs are pointing to a reasonable place (e.g. your own forks on GitHub)
+
+Once you have configured master.ini build the buildmaster container:
+
+    cd /full/path/to/buildbot-host
+    ./rebuild.sh buildmaster
+
+Then launch the buildmaster container, stopping and removing old instances in the process:
+
+    cd /full/path/to/buildbot-host/buildmaster
+    ./launch v2.3.2
+
+Buildbot master should now be listening on port 8010.
 
 # Logging into the Windows VMs from Linux
 

--- a/buildbot-host/provision.sh
+++ b/buildbot-host/provision.sh
@@ -67,7 +67,26 @@ systemctl daemon-reload
 systemctl restart docker
 
 cd $BASEDIR
+
+# Create dummy certificates. Without this - or real certificates - container
+# image builds will fail.
+#
+# Create dummy Authenticode certificate
+touch buildmaster/authenticode.pfx
+
+# Create dummy t_client ca.crt
+touch t_client/ca.crt
+
+# Create dummy t_client certs and keys.
+for WORKERDIR in $(find -maxdepth 1 -type d -name "buildbot-worker*"); do
+    touch $WORKERDIR/t_client.crt
+    touch $WORKERDIR/t_client.key
+done
+
+# Build all worker containers
 "${BASEDIR}/rebuild-all.sh"
+
+# Create all volumes
 "${BASEDIR}/create-volumes.sh"
 
 touch "${BASEDIR}/.provision.sh-ran"

--- a/buildbot-host/rebuild-all.sh
+++ b/buildbot-host/rebuild-all.sh
@@ -17,4 +17,6 @@ for DOCKERFILE in $(find -maxdepth 2 -type f -regextype egrep -regex '.*/(Docker
 done
 
 # clean up dangling images and build cache
+docker container prune --force
 docker image prune --force
+docker buildx prune --force

--- a/buildbot-host/rebuild-all.sh
+++ b/buildbot-host/rebuild-all.sh
@@ -17,4 +17,4 @@ for DOCKERFILE in $(find -maxdepth 2 -type f -regextype egrep -regex '.*/(Docker
 done
 
 # clean up dangling images and build cache
-docker system prune --force
+docker image prune --force


### PR DESCRIPTION
This fixes a couple of provisioning issues and improves documentation somewhat. With the provided fixes provisioning a buildmaster worked fine on Ubuntu 20.04, 22.04 and 23.10 even without acccess to t_client keys or authenticode certificates. 