### PR TITLE
Fix some worker defaults

### DIFF
--- a/buildbot-host/buildmaster/worker-default.ini
+++ b/buildbot-host/buildmaster/worker-default.ini
@@ -41,7 +41,7 @@ enable_openvpn3_builds=false
 image=openvpn_community/buildbot-worker-debian-11:v1.0.2
 
 [debian-12]
-image=openvpn_community/buildbot-worker-debian-11:v1.0.0
+image=openvpn_community/buildbot-worker-debian-12:v1.0.0
 
 [debian-unstable]
 image=openvpn_community/buildbot-worker-debian-unstable:v1.0.2
@@ -65,7 +65,7 @@ image=openvpn_community/buildbot-worker-fedora-39:v1.0.0
 enable_debian_builds=false
 
 #[fedora-rawhide]
-#image=openvpn_community/buildbot-worker-fedora-rawhide:v1.0.1
+#image=openvpn_community/buildbot-worker-fedora-rawhide:v1.0.2
 #enable_debian_builds=false
 
 [opensuse-leap-15]


### PR DESCRIPTION
Some of the defaults are broken, which either causes an "worker cannot instantiate" error or launches a wrong Docker image.

Here are the versions of the images from a freshly built system:

```
REPOSITORY                                           TAG       IMAGE ID       CREATED          SIZE
openvpn_community/buildbot-worker-debian-12          v1.0.0    98bc5f55e0c7   2 days ago       965MB
openvpn_community/buildbot-worker-fedora-rawhide     v1.0.2    d4b022596ad2   13 days ago      1.39GB
```