### PR TITLE
Only build openvpn when changing source code or build files

### DIFF
--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -7,6 +7,7 @@ import treq
 import multiprocessing
 import os
 import random
+import re
 import time
 
 from twisted.internet import defer
@@ -513,12 +514,29 @@ for factory_name, factory in factories.items():
 # name lists are not available yet.
 c['schedulers'] = []
 
+# Only build if any of the files in the Change match this regular expression
+openvpn_file_patterns = ["include/.*",
+                         "m4/.*",
+                         "src/compat/.*",
+                         "src/openvpn/.*",
+                         "tests/.*",
+                         "compat.m4",
+                         "config.h\..*",
+                         "configure.ac",
+                         "Makefile.am",
+                         "version.m4",
+                         ".*\.rst",
+                         "doc/Makefile.am"]
+
+openvpn_filter_fn = "^(" + "|".join(openvpn_file_patterns) + ")$"
+
 # Ensure that in OpenVPN 2 we run smoke tests first and only if those pass run
 # the full test suite
 openvpn_smoketest_scheduler = schedulers.SingleBranchScheduler(
                                   name="openvpn-smoketest",
                                   change_filter=util.ChangeFilter(branch  = openvpn_branch,
-                                                                  project = 'openvpn'),
+                                                                  project = 'openvpn',
+                                                                  filter_fn = lambda c: any([re.search(openvpn_filter_fn, f) for f in c.files])),
                                   treeStableTimer=openvpn_tree_stable_timer,
                                   builderNames=builder_names['openvpn-smoketest'])
 
@@ -530,7 +548,8 @@ openvpn_full_scheduler = schedulers.Dependent(
 openvpn_gerrit_smoketest_scheduler = schedulers.SingleBranchScheduler(
                                          name="openvpn-gerrit-smoketest",
                                          change_filter=util.ChangeFilter(filter_fn = lambda c: c.properties.getProperty('event.patchSet.uploader.name') in verified_authors_list and
-                                                                                               c.properties.getProperty('target_branch') in openvpn_branch,
+                                                                                               c.properties.getProperty('target_branch') in openvpn_branch and
+                                                                                               any([re.search(openvpn_filter_fn, f) for f in c.files]),
                                                                              repository_re = '.*gerrit.*',
                                                                              project = 'openvpn'),
                                          treeStableTimer=openvpn_tree_stable_timer,

--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -276,6 +276,7 @@ c['change_source'] = []
 c['change_source'].append(changes.GerritEventLogPoller(baseURL = gerrit_repo_url + '/a',
                                                        auth = ('buildbot', gerrit_user_password),
                                                        gitBaseURL = gerrit_git_base_url,
+                                                       get_files = True,
                                                        handled_events = ["patchset-created"]))
 
 # OpenVPN 2 Git repository


### PR DESCRIPTION
This PR adds a new Change Filter to the openvpn builds. The Change Filter passes a Change instance to a simple lambda function. The lambda function iterates over all the file list (c.files) and checks whether any of the entries matches a regular expression pattern. The regular expression lists all the filename patters that should trigger a build.

If none of the files in the Change do not match the regular expression then a build is not triggered by the Change. Otherwise a build is triggered.

Which files should trigger a build is up for discussion. I picked a selection that seemed reasonable at a quick glance.

References:
* https://docs.buildbot.net/current/manual/configuration/misc/change_filter.html
* https://github.com/buildbot/buildbot/blob/master/master/buildbot/changes/changes.py#L72