### PR TITLE
Buildbot: do not run the full test suite if smoketests fail

### DIFF
--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -371,6 +371,14 @@ factory_name = "openvpn-code-check"
 factories.update({factory_name: (factory, 'unix', 'code-check', 'openvpn')})
 del factory
 
+# OpenVPN 2 smoketest using default configure options
+factory = util.BuildFactory()
+factory = openvpnAddCommonUnixStepsToBuildFactory(factory, "", ccache)
+factory = openvpnAddUnixCompileStepsToBuildFactory(factory, "", ccache)
+factory_name = "smoketest"
+factories.update({factory_name: (factory, 'unix', 'default', 'openvpn-smoketest')})
+del factory
+
 # Basic OpenVPN 2 compile tests on Unix-style operating systems
 for combo in compile_config_opt_combos:
     factory = util.BuildFactory()
@@ -444,7 +452,7 @@ for factory_name, factory in factories.items():
 
       # Disable builds that the worker is not capable of or which we want to
       # skip for other reasons.  These could be thought of as "tags" of sort.
-      build_types = ["openvpn", "openvpn3", "openvpn3-linux", "openssl", "mbedtls", "debian", "ovpn-dco", "code-check"]
+      build_types = ["openvpn", "openvpn-smoketest", "openvpn3", "openvpn3-linux", "openssl", "mbedtls", "debian", "ovpn-dco", "code-check"]
 
       skip_build=False
       for bt in build_types:
@@ -504,21 +512,39 @@ for factory_name, factory in factories.items():
 # We need to create schedulers after the builders, because otherwise the build
 # name lists are not available yet.
 c['schedulers'] = []
-c['schedulers'].append(schedulers.SingleBranchScheduler(
-                        name="openvpn-default",
-                        change_filter=util.ChangeFilter(branch  = openvpn_branch,
-                                                        project = 'openvpn'),
-                        treeStableTimer=openvpn_tree_stable_timer,
-                        builderNames=builder_names['openvpn']))
 
-c['schedulers'].append(schedulers.SingleBranchScheduler(
-                        name="openvpn-gerrit",
-                        change_filter=util.ChangeFilter(filter_fn = lambda c: c.properties.getProperty('event.patchSet.uploader.name') in verified_authors_list and
-                                                                              c.properties.getProperty('target_branch') in openvpn_branch,
-                                                        repository_re = '.*gerrit.*',
-                                                        project = 'openvpn'),
-                        treeStableTimer=openvpn_tree_stable_timer,
-                        builderNames=builder_names['openvpn']))
+# Ensure that in OpenVPN 2 we run smoke tests first and only if those pass run
+# the full test suite
+openvpn_smoketest_scheduler = schedulers.SingleBranchScheduler(
+                                  name="openvpn-smoketest",
+                                  change_filter=util.ChangeFilter(branch  = openvpn_branch,
+                                                                  project = 'openvpn'),
+                                  treeStableTimer=openvpn_tree_stable_timer,
+                                  builderNames=builder_names['openvpn-smoketest'])
+
+openvpn_full_scheduler = schedulers.Dependent(
+                             name="openvpn-full",
+                             upstream=openvpn_smoketest_scheduler,
+                             builderNames=builder_names['openvpn'])
+
+openvpn_gerrit_smoketest_scheduler = schedulers.SingleBranchScheduler(
+                                         name="openvpn-gerrit-smoketest",
+                                         change_filter=util.ChangeFilter(filter_fn = lambda c: c.properties.getProperty('event.patchSet.uploader.name') in verified_authors_list and
+                                                                                               c.properties.getProperty('target_branch') in openvpn_branch,
+                                                                             repository_re = '.*gerrit.*',
+                                                                             project = 'openvpn'),
+                                         treeStableTimer=openvpn_tree_stable_timer,
+                                         builderNames=builder_names['openvpn-smoketest'])
+
+openvpn_gerrit_full_scheduler = schedulers.Dependent(
+                                    name="openvpn-gerrit-full",
+                                    upstream=openvpn_gerrit_smoketest_scheduler,
+                                    builderNames=builder_names['openvpn'])
+
+c['schedulers'].append(openvpn_smoketest_scheduler)
+c['schedulers'].append(openvpn_full_scheduler)
+c['schedulers'].append(openvpn_gerrit_smoketest_scheduler)
+c['schedulers'].append(openvpn_gerrit_full_scheduler)
 
 c['schedulers'].append(schedulers.SingleBranchScheduler(
                         name="openvpn3-default",

--- a/buildbot-host/buildmaster/worker-default.ini
+++ b/buildbot-host/buildmaster/worker-default.ini
@@ -10,6 +10,7 @@ enable_debian_builds=true
 enable_openssl_builds=true
 enable_mbedtls_builds=true
 enable_openvpn_builds=true
+enable_openvpn-smoketest_builds=false
 enable_openvpn3_builds=true
 enable_openvpn3-linux_builds=true
 enable_ovpn-dco_builds=true


### PR DESCRIPTION
This is implemented by adding a new build type ("openvpn-smoketest") that can be enabled on any workers one wishes. The assumption is that smoketest build run the usual build steps without any special configure options on an UNIX-like operating system. If the smoketests pass, then the full test suite is triggered.

Here's an illustration of how this works in practice:

![Buildbot DependentScheler in action](https://github.com/mattock/openvpn-buildbot/assets/1554045/7b2493fc-df12-4a66-a0be-233ff583568f)

The Gerrit part has not been tested, but I don't see any reason why it would not work. As always with new "build types" at least one worker has to have `enable_openvpn-smoketest_builds=true` or the buildmaster will choke trying to find Builder candidates.

Which workers to run the smoketests on is unrelated to this PR as it only affects the local worker.ini. That said, if we want smoketests other than "default *NIX build with no configure flags" then this PR will need modifications.