### PR TITLE
openvpn3: Do not reuse previous CMake directory

### DIFF
--- a/buildbot-host/buildmaster/openvpn3/common_linux_steps.cfg
+++ b/buildbot-host/buildmaster/openvpn3/common_linux_steps.cfg
@@ -7,6 +7,10 @@ def openvpn3AddCommonLinuxStepsToBuildFactory(factory, combo):
                                 description="cloning",
                                 descriptionDone="cloning"))
 
+    factory.addStep(steps.ShellCommand(command=["rm", "-fr", "build"],
+                                        name="delete old build directory",
+                                        description="preparing",
+                                        descriptionDone="preparing"))
     factory.addStep(steps.ShellCommand(command=["mkdir", "-p", "build"],
                                         name="create build directory",
                                         description="preparing",


### PR DESCRIPTION
While this mostly works, sometimes it doesn't and then it requires manual cleanup. Instead always clean it up.

Mostly affects static workers like macOS.