### PR TITLE
msibuild: install PowerShell Core to resolve vcpkg_copy_tool_dependencies in pkgconfig build

### DIFF
--- a/jenkins/windows-server/msibuild.pkr.hcl
+++ b/jenkins/windows-server/msibuild.pkr.hcl
@@ -40,6 +40,9 @@ build {
     inline = ["C:/Windows/Temp/scripts/pip.ps1"]
   }
   provisioner "powershell" {
+    inline = ["C:/Windows/Temp/scripts/pwsh.ps1"]
+  }
+  provisioner "powershell" {
     only   = ["amazon-ebs.msibuild-windows-server-2019-2.5"]
     inline = ["C:/Windows/Temp/scripts/vsbuildtools.ps1 -version 2019"]
   }


### PR DESCRIPTION
Last openvpn release build failed for x64 and arm64
Installing pwsh resolves the issue
```
-- Fixing pkgconfig file: C:/buildbot/msbuild/openvpn-build/src/vcpkg/packages/pkgconf_x64-windows/debug/lib/pkgconfig/libpkgconf.pc
CMake Error at scripts/cmake/vcpkg_copy_tool_dependencies.cmake:31 (message):
  Could not find PowerShell Core; please open an issue to report this.
Call Stack (most recent call first):
  scripts/cmake/vcpkg_copy_tools.cmake:48 (vcpkg_copy_tool_dependencies)
  ports/pkgconf/portfile.cmake:79 (vcpkg_copy_tools)
  scripts/ports.cmake:175 (include)


error: building pkgconf:x64-windows failed with: BUILD_FAILED
Elapsed time to handle pkgconf:x64-windows: 11 s
Please ensure you're using the latest port files with `git pull` and `vcpkg update`.
```