### PR TITLE
buildmaster: allow to specify multiple extra_config_opts for workers

### DIFF
--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -487,11 +487,11 @@ for factory_name, factory in factories.items():
 
       o = worker_config.get(worker_name, "openvpn_extra_config_opts")
       if o.startswith("--"):
-        properties['openvpn_extra_config_opts'] = o
+        properties['openvpn_extra_config_opts'] = o.split(" ")
 
       o = worker_config.get(worker_name, "openvpn3_linux_extra_config_opts")
       if o.startswith("--"):
-        properties['openvpn3_linux_extra_config_opts'] = o
+        properties['openvpn3_linux_extra_config_opts'] = o.split(" ")
 
       cp = json.loads(worker_config.get(worker_name, "openvpn3_linux_command_prefix"))
       properties['openvpn3_linux_command_prefix'] = cp

--- a/buildbot-host/buildmaster/openvpn/common_unix_steps.cfg
+++ b/buildbot-host/buildmaster/openvpn/common_unix_steps.cfg
@@ -23,7 +23,7 @@ def openvpnAddCommonUnixStepsToBuildFactory(factory, combo, shell_env=None):
                                         descriptionDone="reconfiguring",
                                         env=shell_env))
 
-    configure = ["./configure"] + combo.split(" ") + [util.Interpolate('%(prop:openvpn_extra_config_opts)s')]
+    configure = ["./configure"] + combo.split(" ") + [util.Property('openvpn_extra_config_opts', default=[])]
 
     factory.addStep(steps.ShellCommand(command=configure,
                                         name="configure",

--- a/buildbot-host/buildmaster/openvpn3-linux/common_linux_steps.cfg
+++ b/buildbot-host/buildmaster/openvpn3-linux/common_linux_steps.cfg
@@ -12,7 +12,7 @@ def openvpn3LinuxAddCommonLinuxStepsToBuildFactory(factory, config_opts):
                                         description="bootstrap",
                                         descriptionDone="bootstrap"))
 
-    factory.addStep(steps.ShellCommand(command=[util.Property('openvpn3_linux_command_prefix')] + ["./configure"] + config_opts + [util.Interpolate('%(prop:openvpn3_linux_extra_config_opts)s')],
+    factory.addStep(steps.ShellCommand(command=[util.Property('openvpn3_linux_command_prefix')] + ["./configure"] + config_opts + [util.Property('openvpn3_linux_extra_config_opts', default=[])],
                                         name="configure",
                                         description="configuring",
                                         descriptionDone="configuring"))


### PR DESCRIPTION
Previously this did not work since they were interpreted as one argument. Allow to use a list property.