### PR TITLE
msibuild: Update WiX to 3.14.1

### DIFF
--- a/jenkins/windows-server/msibuild.pkr.hcl
+++ b/jenkins/windows-server/msibuild.pkr.hcl
@@ -1,11 +1,11 @@
 build {
   source "amazon-ebs.windows-server-2019" {
     name     = "msibuild-windows-server-2019-2.5"
-    ami_name = "msibuild-windows-server-2019-2.5-3"
+    ami_name = "msibuild-windows-server-2019-2.5-4"
   }
   source "amazon-ebs.windows-server-2022" {
     name     = "msibuild-windows-server-2022-2.6"
-    ami_name = "msibuild-windows-server-2022-2.6-4"
+    ami_name = "msibuild-windows-server-2022-2.6-5"
   }
 
   provisioner "file" {

--- a/scripts/msibuilder.ps1
+++ b/scripts/msibuilder.ps1
@@ -2,10 +2,10 @@ Write-Host "Installing dependencies for building MSI packages"
 
 . $PSScriptRoot\ps_support.ps1
 
-# Chocolatey package bundles WiX version too old for building ARM64 MSIs.
+# Chocolatey package doesn't install correctly
 #& choco.exe install -y wixtoolset
 
-Invoke-WebRequest -Uri "https://build.openvpn.net/downloads/temp/wix314.exe" -Outfile "C:\Windows\Temp\wix314.exe"
+Invoke-WebRequest -Uri "https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314.exe" -Outfile "C:\Windows\Temp\wix314.exe"
 
 & "C:\Windows\Temp\wix314.exe" /q
 CheckLastExitCode


### PR DESCRIPTION
chocolatey now has updated packages but they don't install because they try to install 8 years old DotNet 3.5 package that fails. Just continue to use the installer directly.