### PR TITLE
Update buildmaster container version to v2.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Once you have configured master.ini build the buildmaster container:
 Then launch the buildmaster container, stopping and removing old instances in the process:
 
     cd /full/path/to/buildbot-host/buildmaster
-    ./launch v2.3.2
+    ./launch v2.5.0
 
 Buildbot master should now be listening on port 8010.
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Once you have configured master.ini build the buildmaster container:
 Then launch the buildmaster container, stopping and removing old instances in the process:
 
     cd /full/path/to/buildbot-host/buildmaster
-    ./launch v2.5.0
+    ./launch.sh v2.5.0
 
 Buildbot master should now be listening on port 8010.
 


### PR DESCRIPTION
The Dockerfile under buildmaster directory is v2.5.0.

The README has been updated to adopt this version change so that when running the ./launch script the correct version will be used and launch the docker container.