### PR TITLE
Distribution Updates April 2024

### DIFF
--- a/buildbot-host/buildbot-worker-fedora-38/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-fedora-38/Dockerfile.base
@@ -1,5 +1,0 @@
-ARG IMAGE=fedora:38
-ARG DEPS_SH=install-openvpn-build-deps-fedora.sh
-ARG MY_NAME="buildbot-worker-fedora-38"
-ARG MY_VERSION="v1.0.1"
-ARG ASIO_REF="asio-1-18-2"

--- a/buildbot-host/buildbot-worker-fedora-40/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-fedora-40/Dockerfile.base
@@ -1,0 +1,5 @@
+ARG IMAGE=fedora:40
+ARG DEPS_SH=install-openvpn-build-deps-fedora.sh
+ARG MY_NAME="buildbot-worker-fedora-40"
+ARG MY_VERSION="v1.0.0"
+ARG ASIO_REF="asio-1-18-2"

--- a/buildbot-host/buildbot-worker-fedora-40/env
+++ b/buildbot-host/buildbot-worker-fedora-40/env
@@ -1,3 +1,3 @@
 BUILDMASTER=buildmaster
-WORKERNAME=fedora-38
+WORKERNAME=fedora-40
 WORKERPASS=vagrant

--- a/buildbot-host/buildbot-worker-ubuntu-2404/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-ubuntu-2404/Dockerfile.base
@@ -1,6 +1,6 @@
-ARG IMAGE=ubuntu:23.10
+ARG IMAGE=ubuntu:24.04
 ARG DEPS_SH=install-openvpn-build-deps-ubuntu.sh
-ARG MY_NAME="buildbot-worker-ubuntu-2310"
+ARG MY_NAME="buildbot-worker-ubuntu-2404"
 ARG PIP_INSTALL_OPTS="--break-system-packages"
 ARG MY_VERSION="v1.0.0"
 ARG ASIO_REF="asio-1-18-2"

--- a/buildbot-host/buildbot-worker-ubuntu-2404/env
+++ b/buildbot-host/buildbot-worker-ubuntu-2404/env
@@ -1,3 +1,3 @@
 BUILDMASTER=buildmaster
-WORKERNAME=ubuntu-2310
+WORKERNAME=ubuntu-2404
 WORKERPASS=vagrant

--- a/buildbot-host/buildmaster/worker-default.ini
+++ b/buildbot-host/buildmaster/worker-default.ini
@@ -57,12 +57,12 @@ enable_debian_builds=false
 enable_openvpn3_builds=false
 enable_openvpn3-linux_builds=false
 
-[fedora-38]
-image=openvpn_community/buildbot-worker-fedora-38:v1.0.1
-enable_debian_builds=false
-
 [fedora-39]
 image=openvpn_community/buildbot-worker-fedora-39:v1.0.0
+enable_debian_builds=false
+
+[fedora-40]
+image=openvpn_community/buildbot-worker-fedora-40:v1.0.0
 enable_debian_builds=false
 
 #[fedora-rawhide]
@@ -87,8 +87,8 @@ image=openvpn_community/buildbot-worker-ubuntu-2004:v1.0.2
 image=openvpn_community/buildbot-worker-ubuntu-2204:v1.0.1
 enable_code-check_builds=true
 
-[ubuntu-2310]
-image=openvpn_community/buildbot-worker-ubuntu-2310:v1.0.0
+[ubuntu-2404]
+image=openvpn_community/buildbot-worker-ubuntu-2404:v1.0.0
 
 #[macos-amd64]
 #type=normal


### PR DESCRIPTION
- Replace Fedora 38 with Fedora 40
- Replace Ubuntu Mantic with Ubuntu Noble (Since Mantic is not LTS)