### PR TITLE
buildbot-host/buildmaster: Create separate schedulers per OpenVPN branch

### DIFF
--- a/buildbot-host/buildmaster/master-default.ini
+++ b/buildbot-host/buildmaster/master-default.ini
@@ -21,7 +21,8 @@ verified_authors_list=[
 
 [openvpn]
 repo_url=https://github.com/OpenVPN/openvpn.git
-branch=["master", "release/2.5"]
+main_branch=master
+release_branch=release/2.6
 run_tclient_tests=False
 # Seconds to wait for new commits before launching the builds. Use None to
 # or 0 to build immediately on commit.

--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -215,7 +215,8 @@ gerrit_user_password = master_config.get("gerrit", "user_password")
 
 # openvpn settings
 openvpn_repo_url = master_config.get("openvpn", "repo_url")
-openvpn_branch = json.loads(master_config.get("openvpn", "branch"))
+openvpn_main_branch = master_config.get("openvpn", "main_branch")
+openvpn_release_branch = master_config.get("openvpn", "release_branch")
 openvpn_run_tclient_tests = master_config.getboolean("openvpn", "run_tclient_tests")
 otst = master_config.get("openvpn", "tree_stable_timer")
 openvpn_tree_stable_timer = None if otst == "None" else int(otst)
@@ -244,7 +245,18 @@ ovpn_dco_tree_stable_timer = None if odtst == "None" else int(odtst)
 # section gives the default settings and gets filtered out automatically, i.e.
 # does not become a worker.
 worker_names = worker_config.sections()
+# Create a list of builders for each scheduler we will create
 builder_names = {}
+scheduler_names = [
+    "openvpn_main",
+    "openvpn_release",
+    "openvpn-smoketest",
+    "openvpn3",
+    "openvpn3-linux",
+    "ovpn-dco"
+]
+for scheduler in scheduler_names:
+    builder_names[scheduler] = []
 
 # Load configuration options used for packaging, connectivity testing and compile tests
 build_and_test_config_opt_combos = json.loads(
@@ -330,7 +342,7 @@ c["change_source"].append(
 c["change_source"].append(
     changes.GitPoller(
         repourl=openvpn_repo_url,
-        branches=openvpn_branch,
+        branches=[openvpn_main_branch, openvpn_release_branch],
         project="openvpn",
         workdir="persistent/gitpoller-workdir-openvpn",
         pollInterval=10,
@@ -378,7 +390,6 @@ docker_build_lock = util.MasterLock("docker", maxCount=2 * cpus)
 # convenience feature to reduce the number of keys required for t_client tests.
 docker_tclient_lock = util.MasterLock("docker", maxCount=1)
 
-factories = {}
 
 
 def getBuilderNameSuffix(combo):
@@ -470,11 +481,22 @@ ccache = {
     "CCACHE_MAXSIZE": "1Gi",
 }
 
+factories = {}
+
 # OpenVPN 2 Uncrustify code check
 factory = util.BuildFactory()
 factory = openvpnAddUncrustifyStepsToBuildFactory(factory, ccache)
 factory_name = "openvpn-code-check"
-factories.update({factory_name: (factory, "unix", "code-check", "openvpn")})
+factories.update(
+    {
+        factory_name: {
+            "factory": factory,
+            "os": "unix",
+            "types": ["code-check", "openvpn"],
+            "schedulers": ["openvpn_main", "openvpn_release"],
+        }
+    }
+)
 del factory
 
 # OpenVPN 2 smoketest using default configure options
@@ -482,7 +504,16 @@ factory = util.BuildFactory()
 factory = openvpnAddCommonUnixStepsToBuildFactory(factory, "", ccache)
 factory = openvpnAddUnixCompileStepsToBuildFactory(factory, "", ccache)
 factory_name = "smoketest"
-factories.update({factory_name: (factory, "unix", "default", "openvpn-smoketest")})
+factories.update(
+    {
+        factory_name: {
+            "factory": factory,
+            "os": "unix",
+            "types": ["openvpn-smoketest"],
+            "schedulers": ["openvpn-smoketest"],
+        }
+    }
+)
 del factory
 
 # Basic OpenVPN 2 compile tests on Unix-style operating systems
@@ -491,7 +522,16 @@ for combo in compile_config_opt_combos:
     factory = openvpnAddCommonUnixStepsToBuildFactory(factory, combo, ccache)
     factory = openvpnAddUnixCompileStepsToBuildFactory(factory, combo, ccache)
     factory_name = getFactoryName(combo)
-    factories.update({factory_name: (factory, "unix", "default", "openvpn")})
+    factories.update(
+        {
+            factory_name: {
+                "factory": factory,
+                "os": "unix",
+                "types": ["openvpn"],
+                "schedulers": ["openvpn_main", "openvpn_release"],
+            }
+        }
+    )
     del factory
 
 # OpenVPN 2 connectivity tests on Unix-style operating systems
@@ -502,7 +542,16 @@ if openvpn_run_tclient_tests:
         factory = openvpnAddUnixCompileStepsToBuildFactory(factory, combo, ccache)
         factory = openvpnAddTClientStepsToBuildFactory(factory, combo, ccache)
         factory_name = getFactoryName(combo)
-        factories.update({factory_name: (factory, "unix", "default", "openvpn")})
+        factories.update(
+            {
+                factory_name: {
+                    "factory": factory,
+                    "os": "unix",
+                    "types": ["openvpn"],
+                    "schedulers": ["openvpn_main", "openvpn_release"],
+                }
+            }
+        )
         del factory
 
 # OpenVPN 2 Debian and Ubuntu packaging
@@ -511,21 +560,48 @@ for combo in packaging_config_opt_combos:
     factory = openvpnAddCommonUnixStepsToBuildFactory(factory, "")
     factory = openvpnAddDebianPackagingStepsToBuildFactory(factory, "")
     factory_name = getFactoryName("-package")
-    factories.update({factory_name: (factory, "unix", "debian", "openvpn")})
+    factories.update(
+        {
+            factory_name: {
+                "factory": factory,
+                "os": "unix",
+                "types": ["debian", "openvpn"],
+                "schedulers": ["openvpn_main", "openvpn_release"],
+            }
+        }
+    )
     del factory
 
 # OpenVPN 2 Windows msbuild tests
 factory = util.BuildFactory()
 factory = openvpnAddCommonWindowsStepsToBuildFactory(factory, combo)
 factory_name = "msbuild"
-factories.update({factory_name: (factory, "windows", "default", "openvpn")})
+factories.update(
+    {
+        factory_name: {
+            "factory": factory,
+            "os": "windows",
+            "types": ["openvpn"],
+            "schedulers": ["openvpn_main", "openvpn_release"],
+        }
+    }
+)
 del factory
 
 # Basic openvpn3 builds
 factory = util.BuildFactory()
 factory = openvpn3AddCommonLinuxStepsToBuildFactory(factory, combo)
 factory_name = "openvpn3"
-factories.update({factory_name: (factory, "unix", "default", "openvpn3")})
+factories.update(
+    {
+        factory_name: {
+            "factory": factory,
+            "os": "unix",
+            "types": ["openvpn3"],
+            "schedulers": ["openvpn3"],
+        }
+    }
+)
 del factory
 
 # OpenSSL openvpn3-linux builds
@@ -534,7 +610,16 @@ factory = openvpn3LinuxAddCommonLinuxStepsToBuildFactory(
     factory, ["--with-crypto-library=openssl"]
 )
 factory_name = "openvpn3-linux-openssl"
-factories.update({factory_name: (factory, "unix", "openssl", "openvpn3-linux")})
+factories.update(
+    {
+        factory_name: {
+            "factory": factory,
+            "os": "unix",
+            "types": ["openssl", "openvpn3-linux"],
+            "schedulers": ["openvpn3-linux"],
+        }
+    }
+)
 del factory
 
 # MbedTLS openvpn3-linux builds
@@ -543,25 +628,43 @@ factory = openvpn3LinuxAddCommonLinuxStepsToBuildFactory(
     factory, ["--with-crypto-library=mbedtls"]
 )
 factory_name = "openvpn3-linux-mbedtls"
-factories.update({factory_name: (factory, "unix", "mbedtls", "openvpn3-linux")})
+factories.update(
+    {
+        factory_name: {
+            "factory": factory,
+            "os": "unix",
+            "types": ["mbedtls", "openvpn3-linux"],
+            "schedulers": ["openvpn3-linux"],
+        }
+    }
+)
 del factory
 
 # Basic ovpn-dco builds
 factory = util.BuildFactory()
 factory = ovpnDcoAddCommonLinuxStepsToBuildFactory(factory, combo)
 factory_name = "ovpn-dco"
-factories.update({factory_name: (factory, "unix", "default", "ovpn-dco")})
+factories.update(
+    {
+        factory_name: {
+            "factory": factory,
+            "os": "unix",
+            "types": ["ovpn-dco"],
+            "schedulers": ["ovpn-dco"],
+        }
+    }
+)
 del factory
 
 # Create the builders
 for factory_name, factory in factories.items():
     for worker_name in worker_names:
         # Check if this factory is applicable for the worker's operating system
-        if not factory[1] == worker_config.get(worker_name, "ostype"):
+        if factory["os"] != worker_config.get(worker_name, "ostype"):
             continue
 
         # Disable builds that the worker is not capable of or which we want to
-        # skip for other reasons.  These could be thought of as "tags" of sort.
+        # skip for other reasons.  These could be thought of as tags of sort.
         build_types = [
             "openvpn",
             "openvpn-smoketest",
@@ -576,7 +679,7 @@ for factory_name, factory in factories.items():
 
         skip_build = False
         for bt in build_types:
-            if factory[2] == bt or factory[3] == bt:
+            if bt in factory["types"]:
                 if worker_config.get(worker_name, f"enable_{bt}_builds") != "true":
                     skip_build = True
         if skip_build:
@@ -618,7 +721,7 @@ for factory_name, factory in factories.items():
             util.BuilderConfig(
                 name=builder_name,
                 workernames=[worker_name],
-                factory=factory[0],
+                factory=factory["factory"],
                 properties=properties,
                 locks=locks,
             )
@@ -626,11 +729,12 @@ for factory_name, factory in factories.items():
 
         # The schedulers need a list of applicable builder names. In practice we
         # need different set of builders for each project we are tracking.
-        try:
-            builder_names[factory[3]]
-        except KeyError:
-            builder_names[factory[3]] = []
-        builder_names[factory[3]].append(builder_name)
+        for scheduler in factory["schedulers"]:
+            # in most cases we filter schedulers via the build type but in the
+            # case of openvpn we have one build-type but two different schedulers
+            # so we can filter builder names additionally by target branch
+            if worker_config.get(worker_name, f"enable_{scheduler}_builds") == "true":
+                builder_names[scheduler].append(builder_name)
 
 # We need to create schedulers after the builders, because otherwise the build
 # name lists are not available yet.
@@ -654,49 +758,51 @@ openvpn_file_patterns = [
 
 openvpn_filter_fn = "^(" + "|".join(openvpn_file_patterns) + ")$"
 
-# Ensure that in OpenVPN 2 we run smoke tests first and only if those pass run
-# the full test suite
-openvpn_smoketest_scheduler = schedulers.SingleBranchScheduler(
-    name="openvpn-smoketest",
-    change_filter=util.ChangeFilter(
-        branch=openvpn_branch,
-        project="openvpn",
-        filter_fn=lambda c: any([re.search(openvpn_filter_fn, f) for f in c.files]),
-    ),
-    treeStableTimer=openvpn_tree_stable_timer,
-    builderNames=builder_names["openvpn-smoketest"],
-)
+openvpn_branches = {"main": openvpn_main_branch, "release": openvpn_release_branch}
+for branch_type, branch_name in openvpn_branches.items():
+    # Ensure that in OpenVPN 2 we run smoke tests first and only if those pass run
+    # the full test suite
+    openvpn_smoketest_scheduler = schedulers.SingleBranchScheduler(
+        name=f"openvpn-smoketest-{branch_type}",
+        change_filter=util.ChangeFilter(
+            branch=branch_name,
+            project="openvpn",
+            filter_fn=lambda c: any([re.search(openvpn_filter_fn, f) for f in c.files]),
+        ),
+        treeStableTimer=openvpn_tree_stable_timer,
+        builderNames=builder_names["openvpn-smoketest"],
+    )
 
-openvpn_full_scheduler = schedulers.Dependent(
-    name="openvpn-full",
-    upstream=openvpn_smoketest_scheduler,
-    builderNames=builder_names["openvpn"],
-)
+    openvpn_full_scheduler = schedulers.Dependent(
+        name=f"openvpn-full-{branch_type}",
+        upstream=openvpn_smoketest_scheduler,
+        builderNames=builder_names[f"openvpn_{branch_type}"],
+    )
 
-openvpn_gerrit_smoketest_scheduler = schedulers.SingleBranchScheduler(
-    name="openvpn-gerrit-smoketest",
-    change_filter=util.ChangeFilter(
-        filter_fn=lambda c: c.properties.getProperty("event.patchSet.uploader.name")
-        in verified_authors_list
-        and c.properties.getProperty("target_branch") in openvpn_branch
-        and any([re.search(openvpn_filter_fn, f) for f in c.files]),
-        repository_re=".*gerrit.*",
-        project="openvpn",
-    ),
-    treeStableTimer=openvpn_tree_stable_timer,
-    builderNames=builder_names["openvpn-smoketest"],
-)
+    openvpn_gerrit_smoketest_scheduler = schedulers.SingleBranchScheduler(
+        name=f"openvpn-gerrit-smoketest-{branch_type}",
+        change_filter=util.ChangeFilter(
+            filter_fn=lambda c: c.properties.getProperty("event.patchSet.uploader.name")
+            in verified_authors_list
+            and c.properties.getProperty("target_branch") == branch_name
+            and any([re.search(openvpn_filter_fn, f) for f in c.files]),
+            repository_re=".*gerrit.*",
+            project="openvpn",
+        ),
+        treeStableTimer=openvpn_tree_stable_timer,
+        builderNames=builder_names["openvpn-smoketest"],
+    )
 
-openvpn_gerrit_full_scheduler = schedulers.Dependent(
-    name="openvpn-gerrit-full",
-    upstream=openvpn_gerrit_smoketest_scheduler,
-    builderNames=builder_names["openvpn"],
-)
+    openvpn_gerrit_full_scheduler = schedulers.Dependent(
+        name=f"openvpn-gerrit-full-{branch_type}",
+        upstream=openvpn_gerrit_smoketest_scheduler,
+        builderNames=builder_names[f"openvpn_{branch_type}"],
+    )
 
-c["schedulers"].append(openvpn_smoketest_scheduler)
-c["schedulers"].append(openvpn_full_scheduler)
-c["schedulers"].append(openvpn_gerrit_smoketest_scheduler)
-c["schedulers"].append(openvpn_gerrit_full_scheduler)
+    c["schedulers"].append(openvpn_smoketest_scheduler)
+    c["schedulers"].append(openvpn_full_scheduler)
+    c["schedulers"].append(openvpn_gerrit_smoketest_scheduler)
+    c["schedulers"].append(openvpn_gerrit_full_scheduler)
 
 c["schedulers"].append(
     schedulers.SingleBranchScheduler(
@@ -729,7 +835,7 @@ c["schedulers"].append(
 
 c["schedulers"].append(
     schedulers.ForceScheduler(
-        name="openvpn-force", builderNames=builder_names["openvpn"]
+        name="openvpn-force", builderNames=builder_names["openvpn_main"]
     )
 )
 

--- a/buildbot-host/buildmaster/worker-default.ini
+++ b/buildbot-host/buildmaster/worker-default.ini
@@ -10,6 +10,8 @@ enable_debian_builds=true
 enable_openssl_builds=true
 enable_mbedtls_builds=true
 enable_openvpn_builds=true
+enable_openvpn_main_builds=true
+enable_openvpn_release_builds=true
 enable_openvpn-smoketest_builds=false
 enable_openvpn3_builds=true
 enable_openvpn3-linux_builds=true
@@ -30,6 +32,8 @@ enable_openvpn3_builds=false
 enable_ovpn-dco_builds=false
 openvpn_extra_config_opts=--disable-dco
 enable_debian_builds=false
+# OpenSSL 1.0.2
+enable_openvpn_main_builds=false
 
 [debian-10]
 image=openvpn_community/buildbot-worker-debian-10:v1.0.2


### PR DESCRIPTION
So that we can have separate builder lists per branch.

To facilitate this, refactor the factory management to be more flexible.

There is an even more general solution possible here by making the builder list a function instead and then dynamically determining builders per incoming change. This felt like too much added complexity for now, so I decided to go for the less flexible but also less complicated solution.