### PR TITLE
Support t_server_null tests

### DIFF
--- a/buildbot-host/buildbot-worker-alpine-3/t_server_null.rc
+++ b/buildbot-host/buildbot-worker-alpine-3/t_server_null.rc
@@ -1,0 +1,1 @@
+# This empty t_server_null.rc is enough to enable t_server_null.sh tests

--- a/buildbot-host/buildbot-worker-arch/t_server_null.rc
+++ b/buildbot-host/buildbot-worker-arch/t_server_null.rc
@@ -1,0 +1,1 @@
+# This empty t_server_null.rc is enough to enable t_server_null.sh tests

--- a/buildbot-host/buildbot-worker-centos-7/t_server_null.rc
+++ b/buildbot-host/buildbot-worker-centos-7/t_server_null.rc
@@ -1,0 +1,1 @@
+# This empty t_server_null.rc is enough to enable t_server_null.sh tests

--- a/buildbot-host/buildbot-worker-debian-10/t_server_null.rc
+++ b/buildbot-host/buildbot-worker-debian-10/t_server_null.rc
@@ -1,0 +1,1 @@
+# This empty t_server_null.rc is enough to enable t_server_null.sh tests

--- a/buildbot-host/buildbot-worker-debian-11/t_server_null.rc
+++ b/buildbot-host/buildbot-worker-debian-11/t_server_null.rc
@@ -1,0 +1,1 @@
+# This empty t_server_null.rc is enough to enable t_server_null.sh tests

--- a/buildbot-host/buildbot-worker-debian-12/t_server_null.rc
+++ b/buildbot-host/buildbot-worker-debian-12/t_server_null.rc
@@ -1,0 +1,1 @@
+# This empty t_server_null.rc is enough to enable t_server_null.sh tests

--- a/buildbot-host/buildbot-worker-debian-unstable/t_server_null.rc
+++ b/buildbot-host/buildbot-worker-debian-unstable/t_server_null.rc
@@ -1,0 +1,1 @@
+# This empty t_server_null.rc is enough to enable t_server_null.sh tests

--- a/buildbot-host/buildbot-worker-fedora-39/t_server_null.rc
+++ b/buildbot-host/buildbot-worker-fedora-39/t_server_null.rc
@@ -1,0 +1,1 @@
+# This empty t_server_null.rc is enough to enable t_server_null.sh tests

--- a/buildbot-host/buildbot-worker-fedora-40/t_server_null.rc
+++ b/buildbot-host/buildbot-worker-fedora-40/t_server_null.rc
@@ -1,0 +1,1 @@
+# This empty t_server_null.rc is enough to enable t_server_null.sh tests

--- a/buildbot-host/buildbot-worker-fedora-rawhide/t_server_null.rc
+++ b/buildbot-host/buildbot-worker-fedora-rawhide/t_server_null.rc
@@ -1,0 +1,1 @@
+# This empty t_server_null.rc is enough to enable t_server_null.sh tests

--- a/buildbot-host/buildbot-worker-opensuse-leap-15/t_server_null.rc
+++ b/buildbot-host/buildbot-worker-opensuse-leap-15/t_server_null.rc
@@ -1,0 +1,1 @@
+# This empty t_server_null.rc is enough to enable t_server_null.sh tests

--- a/buildbot-host/buildbot-worker-ubuntu-2004/t_server_null.rc
+++ b/buildbot-host/buildbot-worker-ubuntu-2004/t_server_null.rc
@@ -1,0 +1,1 @@
+# This empty t_server_null.rc is enough to enable t_server_null.sh tests

--- a/buildbot-host/buildbot-worker-ubuntu-2204/t_server_null.rc
+++ b/buildbot-host/buildbot-worker-ubuntu-2204/t_server_null.rc
@@ -1,0 +1,1 @@
+# This empty t_server_null.rc is enough to enable t_server_null.sh tests

--- a/buildbot-host/buildbot-worker-ubuntu-2404/t_server_null.rc
+++ b/buildbot-host/buildbot-worker-ubuntu-2404/t_server_null.rc
@@ -1,0 +1,1 @@
+# This empty t_server_null.rc is enough to enable t_server_null.sh tests

--- a/buildbot-host/buildmaster/master-default.ini
+++ b/buildbot-host/buildmaster/master-default.ini
@@ -24,7 +24,6 @@ repo_url=https://github.com/OpenVPN/openvpn.git
 main_branch=master
 release_branch=release/2.6
 run_tclient_tests=False
-run_tserver_null_tests=True
 # Seconds to wait for new commits before launching the builds. Use None to
 # or 0 to build immediately on commit.
 tree_stable_timer=0

--- a/buildbot-host/buildmaster/master-default.ini
+++ b/buildbot-host/buildmaster/master-default.ini
@@ -24,6 +24,7 @@ repo_url=https://github.com/OpenVPN/openvpn.git
 main_branch=master
 release_branch=release/2.6
 run_tclient_tests=False
+run_tserver_null_tests=True
 # Seconds to wait for new commits before launching the builds. Use None to
 # or 0 to build immediately on commit.
 tree_stable_timer=0

--- a/buildbot-host/buildmaster/master-default.ini
+++ b/buildbot-host/buildmaster/master-default.ini
@@ -16,7 +16,7 @@ git_base_url=https://gerrit.localhost
 user_password=password
 verified_authors_list=[
     "user1",
-    "user2",
+    "user2"
     ]
 
 [openvpn]

--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -540,16 +540,16 @@ for combo in compile_config_opt_combos:
     del factory
 
 # OpenVPN 2 connectivity tests on Unix-style operating systems
-if openvpn_run_tclient_tests:
+if openvpn_run_tclient_tests or openvpn_run_tserver_null_tests:
     for combo in build_and_test_config_opt_combos:
         factory = util.BuildFactory()
         factory = openvpnAddCommonUnixStepsToBuildFactory(factory, combo, ccache)
         factory = openvpnAddUnixCompileStepsToBuildFactory(factory, combo, ccache)
         factory = openvpnAddDeviceSetupStepsToBuildFactory(factory, combo, ccache)
-        factory = openvpnAddTServerNullPreStepsToBuildFactory(factory, combo, ccache)
-        factory = openvpnAddTClientPreStepsToBuildFactory(factory, combo, ccache)
+        if openvpn_run_tserver_null_tests: factory = openvpnAddTServerNullPreStepsToBuildFactory(factory, combo, ccache)
+        if openvpn_run_tclient_tests: factory = openvpnAddTClientPreStepsToBuildFactory(factory, combo, ccache)
         factory = openvpnAddCheckStepsToBuildFactory(factory, combo, ccache)
-        factory = openvpnAddTClientPostStepsToBuildFactory(factory, combo, ccache)
+        if openvpn_run_tclient_tests: factory = openvpnAddTClientPostStepsToBuildFactory(factory, combo, ccache)
         factory_name = getFactoryName(combo)
         factories.update(
             {

--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -217,6 +217,7 @@ gerrit_user_password = master_config.get("gerrit", "user_password")
 openvpn_repo_url = master_config.get("openvpn", "repo_url")
 openvpn_main_branch = master_config.get("openvpn", "main_branch")
 openvpn_release_branch = master_config.get("openvpn", "release_branch")
+openvpn_run_tserver_null_tests = master_config.getboolean("openvpn", "run_tserver_null_tests")
 openvpn_run_tclient_tests = master_config.getboolean("openvpn", "run_tclient_tests")
 otst = master_config.get("openvpn", "tree_stable_timer")
 openvpn_tree_stable_timer = None if otst == "None" else int(otst)
@@ -427,6 +428,8 @@ for steps_file in [
     "common_unix_steps.cfg",
     "common_windows_steps.cfg",
     "debian_packaging_steps.cfg",
+    "device_setup_steps.cfg",
+    "tserver_null_steps.cfg",
     "tclient_steps.cfg",
     "unix_compile_steps.cfg",
     "uncrustify_code_check.cfg",
@@ -534,12 +537,25 @@ for combo in compile_config_opt_combos:
     )
     del factory
 
+# OpenVPN 2 --dev null server tests on Unix-style operating systems
+if openvpn_run_tserver_null_tests:
+    for combo in build_and_test_config_opt_combos:
+        factory = util.BuildFactory()
+        factory = openvpnAddCommonUnixStepsToBuildFactory(factory, combo, ccache)
+        factory = openvpnAddUnixCompileStepsToBuildFactory(factory, combo, ccache)
+        factory = openvpnAddDeviceSetupStepsToBuildFactory(factory, combo, ccache)
+        factory = openvpnAddTServerNullStepsToBuildFactory(factory, combo, ccache)
+        factory_name = getFactoryName("%s-tserver_null" % (combo))
+        factories.update({factory_name: (factory, 'unix', 'default', 'openvpn')})
+        del factory
+
 # OpenVPN 2 connectivity tests on Unix-style operating systems
 if openvpn_run_tclient_tests:
     for combo in build_and_test_config_opt_combos:
         factory = util.BuildFactory()
         factory = openvpnAddCommonUnixStepsToBuildFactory(factory, combo, ccache)
         factory = openvpnAddUnixCompileStepsToBuildFactory(factory, combo, ccache)
+        factory = openvpnAddDeviceSetupStepsToBuildFactory(factory, combo, ccache)
         factory = openvpnAddTClientStepsToBuildFactory(factory, combo, ccache)
         factory_name = getFactoryName(combo)
         factories.update(
@@ -656,7 +672,11 @@ factories.update(
 )
 del factory
 
-# Create the builders
+# Create the builders from the factories dictionary constructed above. Each
+# entry follows this format:
+#
+# <str factory_name>: (<BuildFactory object>, <str operatingsystem>, <str build-type>, <str project>)
+#
 for factory_name, factory in factories.items():
     for worker_name in worker_names:
         # Check if this factory is applicable for the worker's operating system
@@ -667,6 +687,7 @@ for factory_name, factory in factories.items():
         # skip for other reasons.  These could be thought of as tags of sort.
         build_types = [
             "openvpn",
+            "openvpn-tserver-null",
             "openvpn-smoketest",
             "openvpn3",
             "openvpn3-linux",

--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -542,14 +542,22 @@ for combo in compile_config_opt_combos:
 # OpenVPN 2 connectivity tests on Unix-style operating systems
 if openvpn_run_tclient_tests or openvpn_run_tserver_null_tests:
     for combo in build_and_test_config_opt_combos:
+        make_check_env = {}
+        make_check_env.update(ccache)
+        if openvpn_run_tclient_tests: make_check_env.update({ "TCLIENT_SKIP_RC": "1" })
+
         factory = util.BuildFactory()
-        factory = openvpnAddCommonUnixStepsToBuildFactory(factory, combo, ccache)
-        factory = openvpnAddUnixCompileStepsToBuildFactory(factory, combo, ccache)
-        factory = openvpnAddDeviceSetupStepsToBuildFactory(factory, combo, ccache)
-        if openvpn_run_tserver_null_tests: factory = openvpnAddTServerNullPreStepsToBuildFactory(factory, combo, ccache)
-        if openvpn_run_tclient_tests: factory = openvpnAddTClientPreStepsToBuildFactory(factory, combo, ccache)
-        factory = openvpnAddCheckStepsToBuildFactory(factory, combo, ccache)
-        if openvpn_run_tclient_tests: factory = openvpnAddTClientPostStepsToBuildFactory(factory, combo, ccache)
+        factory = openvpnAddCommonUnixStepsToBuildFactory(factory, combo, make_check_env)
+        factory = openvpnAddUnixCompileStepsToBuildFactory(factory, combo, make_check_env)
+        factory = openvpnAddDeviceSetupStepsToBuildFactory(factory, combo, make_check_env)
+
+        if openvpn_run_tserver_null_tests: factory = openvpnAddTServerNullPreStepsToBuildFactory(factory, combo, make_check_env)
+        if openvpn_run_tclient_tests:      factory = openvpnAddTClientPreStepsToBuildFactory(factory, combo, make_check_env)
+
+        factory = openvpnAddCheckStepsToBuildFactory(factory, combo, make_check_env)
+
+        if openvpn_run_tclient_tests:      factory = openvpnAddTClientPostStepsToBuildFactory(factory, combo, make_check_env)
+
         factory_name = getFactoryName(combo)
         factories.update(
             {

--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -665,11 +665,7 @@ factories.update(
 )
 del factory
 
-# Create the builders from the factories dictionary constructed above. Each
-# entry follows this format:
-#
-# <str factory_name>: (<BuildFactory object>, <str operatingsystem>, <str build-type>, <str project>)
-#
+# Create the builders from the factories dictionary constructed above
 for factory_name, factory in factories.items():
     for worker_name in worker_names:
         # Check if this factory is applicable for the worker's operating system

--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -537,18 +537,6 @@ for combo in compile_config_opt_combos:
     )
     del factory
 
-# OpenVPN 2 --dev null server tests on Unix-style operating systems
-if openvpn_run_tserver_null_tests:
-    for combo in build_and_test_config_opt_combos:
-        factory = util.BuildFactory()
-        factory = openvpnAddCommonUnixStepsToBuildFactory(factory, combo, ccache)
-        factory = openvpnAddUnixCompileStepsToBuildFactory(factory, combo, ccache)
-        factory = openvpnAddDeviceSetupStepsToBuildFactory(factory, combo, ccache)
-        factory = openvpnAddTServerNullStepsToBuildFactory(factory, combo, ccache)
-        factory_name = getFactoryName("%s-tserver_null" % (combo))
-        factories.update({factory_name: (factory, 'unix', 'default', 'openvpn')})
-        del factory
-
 # OpenVPN 2 connectivity tests on Unix-style operating systems
 if openvpn_run_tclient_tests:
     for combo in build_and_test_config_opt_combos:
@@ -556,6 +544,7 @@ if openvpn_run_tclient_tests:
         factory = openvpnAddCommonUnixStepsToBuildFactory(factory, combo, ccache)
         factory = openvpnAddUnixCompileStepsToBuildFactory(factory, combo, ccache)
         factory = openvpnAddDeviceSetupStepsToBuildFactory(factory, combo, ccache)
+        factory = openvpnAddTServerNullStepsToBuildFactory(factory, combo, ccache)
         factory = openvpnAddTClientStepsToBuildFactory(factory, combo, ccache)
         factory_name = getFactoryName(combo)
         factories.update(
@@ -687,7 +676,6 @@ for factory_name, factory in factories.items():
         # skip for other reasons.  These could be thought of as tags of sort.
         build_types = [
             "openvpn",
-            "openvpn-tserver-null",
             "openvpn-smoketest",
             "openvpn3",
             "openvpn3-linux",

--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -429,8 +429,10 @@ for steps_file in [
     "common_windows_steps.cfg",
     "debian_packaging_steps.cfg",
     "device_setup_steps.cfg",
-    "tserver_null_steps.cfg",
-    "tclient_steps.cfg",
+    "tserver_null_pre_steps.cfg",
+    "tclient_pre_steps.cfg",
+    "check_steps.cfg",
+    "tclient_post_steps.cfg",
     "unix_compile_steps.cfg",
     "uncrustify_code_check.cfg",
 ]:
@@ -544,8 +546,10 @@ if openvpn_run_tclient_tests:
         factory = openvpnAddCommonUnixStepsToBuildFactory(factory, combo, ccache)
         factory = openvpnAddUnixCompileStepsToBuildFactory(factory, combo, ccache)
         factory = openvpnAddDeviceSetupStepsToBuildFactory(factory, combo, ccache)
-        factory = openvpnAddTServerNullStepsToBuildFactory(factory, combo, ccache)
-        factory = openvpnAddTClientStepsToBuildFactory(factory, combo, ccache)
+        factory = openvpnAddTServerNullPreStepsToBuildFactory(factory, combo, ccache)
+        factory = openvpnAddTClientPreStepsToBuildFactory(factory, combo, ccache)
+        factory = openvpnAddCheckStepsToBuildFactory(factory, combo, ccache)
+        factory = openvpnAddTClientPostStepsToBuildFactory(factory, combo, ccache)
         factory_name = getFactoryName(combo)
         factories.update(
             {

--- a/buildbot-host/buildmaster/openvpn/check_steps.cfg
+++ b/buildbot-host/buildmaster/openvpn/check_steps.cfg
@@ -1,0 +1,31 @@
+# -*- python -*-
+# ex: set filetype=python:
+def openvpnAddCheckStepsToBuildFactory(factory, combo, shell_env=None):
+    if shell_env is None:
+        shell_env = {}
+
+    # Run the tests, including t_client.sh and t_server_null.sh
+    t_client_env = {"TCLIENT_SKIP_RC": "1"}
+    t_client_env.update(shell_env)
+    factory.addStep(
+        steps.ShellCommand(
+            command=["make", "check", "VERBOSE=1"],
+            env=t_client_env,
+            name="run tests",
+            description="testing",
+            descriptionDone="testing",
+        )
+    )
+
+    factory.addStep(
+        steps.ShellCommand(
+            command="ccache -s",
+            decodeRC={0: SUCCESS, 127: WARNINGS},
+            name="ccache show",
+            description="showing stats",
+            descriptionDone="showing stats",
+            env=shell_env,
+        )
+    )
+
+    return factory

--- a/buildbot-host/buildmaster/openvpn/check_steps.cfg
+++ b/buildbot-host/buildmaster/openvpn/check_steps.cfg
@@ -5,12 +5,10 @@ def openvpnAddCheckStepsToBuildFactory(factory, combo, shell_env=None):
         shell_env = {}
 
     # Run the tests, including t_client.sh and t_server_null.sh
-    t_client_env = {"TCLIENT_SKIP_RC": "1"}
-    t_client_env.update(shell_env)
     factory.addStep(
         steps.ShellCommand(
             command=["make", "check", "VERBOSE=1"],
-            env=t_client_env,
+            env=shell_env,
             name="run tests",
             description="testing",
             descriptionDone="testing",

--- a/buildbot-host/buildmaster/openvpn/device_setup_steps.cfg
+++ b/buildbot-host/buildmaster/openvpn/device_setup_steps.cfg
@@ -12,7 +12,7 @@ def openvpnAddDeviceSetupStepsToBuildFactory(factory, combo, shell_env=None):
             mastersrc="/var/lib/buildbot/masters/default/ensure-tun-is-present.sh",
             workerdest="ensure-tun-is-present.sh",
             mode=0o755,
-            name="download",
+            name="download ensure tun script",
             description="downloading",
             descriptionDone="downloading"
         )

--- a/buildbot-host/buildmaster/openvpn/device_setup_steps.cfg
+++ b/buildbot-host/buildmaster/openvpn/device_setup_steps.cfg
@@ -1,0 +1,31 @@
+# -*- python -*-
+# ex: set filetype=python:
+def openvpnAddDeviceSetupStepsToBuildFactory(factory, combo, shell_env=None):
+    if shell_env is None:
+        shell_env={}
+
+    # Docker container don't have a tun device by default, so ensure they get
+    # one. While this script will run on all *NIX workers, it is a no-op
+    # outside of Docker.
+    factory.addStep(
+        steps.FileDownload(
+            mastersrc="/var/lib/buildbot/masters/default/ensure-tun-is-present.sh",
+            workerdest="ensure-tun-is-present.sh",
+            mode=0o755,
+            name="download",
+            description="downloading",
+            descriptionDone="downloading"
+        )
+    )
+
+    factory.addStep(
+        steps.ShellCommand(
+            command=["./ensure-tun-is-present.sh"],
+            name="ensure tun in docker",
+            description="ensuring",
+            descriptionDone="ensuring",
+            env=shell_env
+        )
+    )
+
+    return factory

--- a/buildbot-host/buildmaster/openvpn/tclient_post_steps.cfg
+++ b/buildbot-host/buildmaster/openvpn/tclient_post_steps.cfg
@@ -1,0 +1,22 @@
+# -*- python -*-
+# ex: set filetype=python:
+def openvpnAddTClientPostStepsToBuildFactory(factory, combo, shell_env=None):
+    if shell_env is None:
+        shell_env = {}
+
+    # Copy the current t_client_ips.rc out of the build directory to restore it later.
+    factory.addStep(
+        steps.ShellCommand(
+            command=[
+                "cp",
+                "-f",
+                "t_client_ips.rc",
+                util.Interpolate("%(prop:persist)s/t_client_ips.rc"),
+            ],
+            name="cache t_client_ips.rc",
+            description="caching",
+            descriptionDone="caching",
+        )
+    )
+
+    return factory

--- a/buildbot-host/buildmaster/openvpn/tclient_pre_steps.cfg
+++ b/buildbot-host/buildmaster/openvpn/tclient_pre_steps.cfg
@@ -1,6 +1,6 @@
 # -*- python -*-
 # ex: set filetype=python:
-def openvpnAddTClientStepsToBuildFactory(factory, combo, shell_env=None):
+def openvpnAddTClientPreStepsToBuildFactory(factory, combo, shell_env=None):
     if shell_env is None:
         shell_env = {}
 
@@ -38,45 +38,6 @@ def openvpnAddTClientStepsToBuildFactory(factory, combo, shell_env=None):
             decodeRC={0: SUCCESS, 1: SUCCESS},
             description="restoring",
             descriptionDone="restoring",
-        )
-    )
-
-    # Run the tests, including t_client.sh
-    t_client_env = {"TCLIENT_SKIP_RC": "1"}
-    t_client_env.update(shell_env)
-    factory.addStep(
-        steps.ShellCommand(
-            command=["make", "check", "VERBOSE=1"],
-            env=t_client_env,
-            name="run tests",
-            description="testing",
-            descriptionDone="testing",
-        )
-    )
-
-    # Copy the current t_client_ips.rc out of the build directory to restore it later.
-    factory.addStep(
-        steps.ShellCommand(
-            command=[
-                "cp",
-                "-f",
-                "t_client_ips.rc",
-                util.Interpolate("%(prop:persist)s/t_client_ips.rc"),
-            ],
-            name="cache t_client_ips.rc",
-            description="caching",
-            descriptionDone="caching",
-        )
-    )
-
-    factory.addStep(
-        steps.ShellCommand(
-            command="ccache -s",
-            decodeRC={0: SUCCESS, 127: WARNINGS},
-            name="ccache show",
-            description="showing stats",
-            descriptionDone="showing stats",
-            env=shell_env,
         )
     )
 

--- a/buildbot-host/buildmaster/openvpn/tclient_steps.cfg
+++ b/buildbot-host/buildmaster/openvpn/tclient_steps.cfg
@@ -41,30 +41,6 @@ def openvpnAddTClientStepsToBuildFactory(factory, combo, shell_env=None):
         )
     )
 
-    # Docker container don't have a tun device by default, so ensure they get
-    # one. While this script will run on all *NIX workers, it is a no-op
-    # outside of Docker.
-    factory.addStep(
-        steps.FileDownload(
-            mastersrc="/var/lib/buildbot/masters/default/ensure-tun-is-present.sh",
-            workerdest="ensure-tun-is-present.sh",
-            mode=0o755,
-            name="download",
-            description="downloading",
-            descriptionDone="downloading",
-        )
-    )
-
-    factory.addStep(
-        steps.ShellCommand(
-            command=["./ensure-tun-is-present.sh"],
-            name="ensure tun in docker",
-            description="ensuring",
-            descriptionDone="ensuring",
-            env=shell_env,
-        )
-    )
-
     # Run the tests, including t_client.sh
     t_client_env = {"TCLIENT_SKIP_RC": "1"}
     t_client_env.update(shell_env)

--- a/buildbot-host/buildmaster/openvpn/tserver_null_pre_steps.cfg
+++ b/buildbot-host/buildmaster/openvpn/tserver_null_pre_steps.cfg
@@ -4,10 +4,13 @@ def openvpnAddTServerNullPreStepsToBuildFactory(factory, combo, shell_env=None):
     if shell_env is None:
         shell_env={}
 
-    factory.addStep(steps.ShellCommand(command=["touch", "tests/t_server_null.rc"],
-                                        env=shell_env,
-                                        name="touch t_server_null.rc",
-                                        description="touching",
-                                        descriptionDone="touching"))
+    factory.addStep(
+        steps.ShellCommand(
+            command=["cp", "-f", "/buildbot/t_server_null.rc", "tests/"],
+            name="copy t_server_null.rc",
+            description="copying",
+            descriptionDone="copying",
+        )
+    )
 
     return factory

--- a/buildbot-host/buildmaster/openvpn/tserver_null_pre_steps.cfg
+++ b/buildbot-host/buildmaster/openvpn/tserver_null_pre_steps.cfg
@@ -1,6 +1,6 @@
 # -*- python -*-
 # ex: set filetype=python:
-def openvpnAddTServerNullStepsToBuildFactory(factory, combo, shell_env=None):
+def openvpnAddTServerNullPreStepsToBuildFactory(factory, combo, shell_env=None):
     if shell_env is None:
         shell_env={}
 

--- a/buildbot-host/buildmaster/openvpn/tserver_null_steps.cfg
+++ b/buildbot-host/buildmaster/openvpn/tserver_null_steps.cfg
@@ -1,0 +1,19 @@
+# -*- python -*-
+# ex: set filetype=python:
+def openvpnAddTServerNullStepsToBuildFactory(factory, combo, shell_env=None):
+    if shell_env is None:
+        shell_env={}
+
+    factory.addStep(steps.ShellCommand(command=["touch", "tests/t_server_null.rc"],
+                                        env=shell_env,
+                                        name="touch t_server_null.rc",
+                                        description="touching",
+                                        descriptionDone="touching"))
+
+    factory.addStep(steps.ShellCommand(command=["make", "check"],
+                                        env=shell_env,
+                                        name="run tests",
+                                        description="testing",
+                                        descriptionDone="testing"))
+
+    return factory

--- a/buildbot-host/buildmaster/openvpn/tserver_null_steps.cfg
+++ b/buildbot-host/buildmaster/openvpn/tserver_null_steps.cfg
@@ -10,10 +10,4 @@ def openvpnAddTServerNullStepsToBuildFactory(factory, combo, shell_env=None):
                                         description="touching",
                                         descriptionDone="touching"))
 
-    factory.addStep(steps.ShellCommand(command=["make", "check"],
-                                        env=shell_env,
-                                        name="run tests",
-                                        description="testing",
-                                        descriptionDone="testing"))
-
     return factory

--- a/buildbot-host/snippets/Dockerfile.common
+++ b/buildbot-host/snippets/Dockerfile.common
@@ -14,7 +14,7 @@ RUN set -ex; \
 # Install buildbot
 ARG MY_NAME
 ARG PIP_INSTALL_OPTS
-COPY scripts/install-buildbot.sh t_client/*.crt t_client/*.rc t_client/*.txt ${MY_NAME}/t_client.* /buildbot/
+COPY scripts/install-buildbot.sh t_client/*.crt t_client/*.rc t_client/*.txt ${MY_NAME}/t_client.* ${MY_NAME}/t_server_null.rc /buildbot/
 RUN set -ex; \
     /buildbot/install-buildbot.sh; \
     rm -f /buildbot/install-buildbot.sh


### PR DESCRIPTION
This PR integrates t_server_null.sh tests into buildbot. It essentially adds a new build type which can be enabled or disabled in master.ini and in each worker's configuration in worker.ini. As it stands now the t_server_null tests will run on the builders that use the same configure flags as those running t_client tests, e.g.

```
build_and_test_config_opt_combos=[
    "",
    "--with-crypto-library=mbedtls"
    ]
```

This change was tested on all latent Linux workers. No t_server_null.sh -induced failures were noted and all tests passed as intended.