### PR TITLE
buildmaster: Fix gerrit schedulers

### DIFF
--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -253,7 +253,7 @@ scheduler_names = [
     "openvpn-smoketest",
     "openvpn3",
     "openvpn3-linux",
-    "ovpn-dco"
+    "ovpn-dco",
 ]
 for scheduler in scheduler_names:
     builder_names[scheduler] = []
@@ -389,7 +389,6 @@ docker_build_lock = util.MasterLock("docker", maxCount=2 * cpus)
 # Only allow one docker worker to run t_client tests at the same time. This is
 # convenience feature to reduce the number of keys required for t_client tests.
 docker_tclient_lock = util.MasterLock("docker", maxCount=1)
-
 
 
 def getBuilderNameSuffix(combo):
@@ -758,6 +757,20 @@ openvpn_file_patterns = [
 
 openvpn_filter_fn = "^(" + "|".join(openvpn_file_patterns) + ")$"
 
+
+def gerrit_filter(branch_name):
+    def filter_func(c):
+        ret = (
+            c.properties.getProperty("event.patchSet.uploader.name")
+            in verified_authors_list
+            and (c.properties.getProperty("target_branch") == branch_name)
+            and any([re.search(openvpn_filter_fn, f) for f in c.files])
+        )
+        return ret
+
+    return filter_func
+
+
 openvpn_branches = {"main": openvpn_main_branch, "release": openvpn_release_branch}
 for branch_type, branch_name in openvpn_branches.items():
     # Ensure that in OpenVPN 2 we run smoke tests first and only if those pass run
@@ -782,10 +795,7 @@ for branch_type, branch_name in openvpn_branches.items():
     openvpn_gerrit_smoketest_scheduler = schedulers.SingleBranchScheduler(
         name=f"openvpn-gerrit-smoketest-{branch_type}",
         change_filter=util.ChangeFilter(
-            filter_fn=lambda c: c.properties.getProperty("event.patchSet.uploader.name")
-            in verified_authors_list
-            and c.properties.getProperty("target_branch") == branch_name
-            and any([re.search(openvpn_filter_fn, f) for f in c.files]),
+            filter_fn=gerrit_filter(branch_name),
             repository_re=".*gerrit.*",
             project="openvpn",
         ),


### PR DESCRIPTION
The filter function used a loop variable which was changed. Need to have use a local variable that is not changed.