### PR TITLE
Support for publishing Debian and Ubuntu snapshots with aptly

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Here's a list of relevant directories:
     * *Dockerfile.base*: a "configuration file" that contains ARG entries that will drive the logic in the main Dockerfile, *snippets/Dockerfile.common*. Used when provisioning the container.
     * *env*: sets environment variables that are required by the worker container (buildmaster, worker name, worker pass). Used when launching *static* containers. Not needed for *latent* workers. In other words, in most cases you can ignore the *env* file.
     * *ec2.pkr.hcl*: Packer code to build EC2 latent buildbot workers
+* *aptly*: files related to Debian/Ubuntu package publishing using aptly; see [buildbot-host/aptly/README.md](buildbot-host/aptly/README.md) for details
 * *scripts*: reusable worker initialization/provisioning scripts
 * *snippets*: configuration fragments; current only the reusable part of the Dockerfile
 

--- a/buildbot-host/aptly/README.md
+++ b/buildbot-host/aptly/README.md
@@ -1,0 +1,127 @@
+# Automatic Debian/Ubuntu snapshot publishing
+
+## Introduction
+
+The openvpn-buildbot repository contains everything needed to publish
+Debian/Ubuntu packages in local aptly repositories. The local aptly
+repositories can then be rsynced to a remote repository if so desired
+using a separate hook script.
+
+## Basic workflow
+
+The package publishing workflow is the following:
+1. On dockerized buildbot workers (Debian/Ubuntu)
+    1. Build the Debian packages
+    1. Save the Debian packages  to their respective Docker volumes
+1. On buildbot (docker) host
+    1. A systemd service monitors the Docker volumes for new packages using *inotifywait*. When it notices a new package it launches the aptly publishing script.
+    1. The publishing script GPG-signs and publishes the package in a local, per-distro (e.g. *debian-12*, *ubuntu-2404*) aptly repository
+    1. An optional hook script runs and is passed the repository name (e.g. *debian-12*) as its first parameters; the script can, for example, rsync the updated per-distro repository over to a remote server
+
+This workflow does not require aptly or its dependencies to be configured on
+each buildbot worker. Aptly runs directly on the buildbot (docker) host instead
+of in a container to further minimize implementation complexity.
+
+## Setup
+
+Debian packages need to be signed. For this to work you must import a private
+GPG key used to sign the packages. The key must be in the default GnuPG keyring
+of the root user.  The keyring should not have any other keys in it or aptly
+might get confused.
+
+In addition you must add the GPG private key passphrase to */etc/aptly.pass*
+and set its ownership and mode properly (e.g. root:root and 0400).
+
+Next install aptly. On Ubuntu:
+
+    cd openvpn-buildbot/buildbot-host/aptly
+    ./setup-aptly-ubuntu.sh
+
+You can do the rest with a simple Debian package install:
+
+    dpkg -i publish-incoming-debian-snapshots_0.9.14-1_amd64.deb
+
+If you don't have the package you can generate it with
+[fpm](https://fpm.readthedocs.io/en/latest/index.html). First install fpm:
+
+    cd openvpn-buildbot/buildbot-host/aptly/fpm
+    ./setup-fpm.sh
+
+Then build the package (can be done from any directory):
+
+    cd openvpn-buildbot/buildbot-host/aptly/fpm
+    ./package.sh
+
+## Using auto-publishing
+
+Tail the systemd service to check if auto-publishing is working:
+
+    journalctl -n0 -f --unit=publish-incoming-debian-snapshots.service
+
+When a buildbot worker finishes a debian packaging build you should see output like this:
+
+```
+Publishing openvpn_2.7-1716968802_amd64.deb in repository debian-11
+Loading packages...
+[+] openvpn_2.7-1716968802_amd64 added
+Generating metadata files and linking package files...
+Finalizing metadata files...
+Signing file 'Release' with gpg, please enter your passphrase when prompted:
+Clearsigning file 'Release' with gpg, please enter your passphrase when prompted:
+Cleaning up prefix "." components main...
+Publish for local repo filesystem:debian-11:./debian-11 [amd64] publishes {main: [debian-11]: Buildbot-generated packages for debian-11)
+has been successfully updated.
+```
+
+## Configuring an auto-publishing hook
+
+The auto-publishing script supports running a hook script after a package has
+been added to the local aptly repository. The script path is expected to be
+*/usr/local/bin/publish-debian-snapshot-hook.sh*. If that script is present and
+is executable it will run automatically whenever a package is added to an aptly
+repository. It gets the aptly repository name (e.g. *debian-12*) as its first
+parameter.
+
+A simple hook script might look like this:
+
+    #!/bin/sh
+    #
+    # /usr/local/bin/publish-debian-snapshot-hook.sh
+    #
+    mkdir -p /var/www/html/apt
+    rsync -va /var/lib/aptly/public/$1 /var/www/html/apt/
+
+This copies the updated aptly repository into a different directory on the
+local filesystem.
+
+# Local aptly repository layout
+
+The out-of-the-box aptly configuration creates a repository layout like this:
+
+```
+$ tree /var/lib/aptly/public/
+/var/lib/aptly/public/
+└── debian-12
+    ├── dists
+    │   └── debian-12
+    │       ├── Contents-amd64.gz
+    │       ├── InRelease
+    │       ├── Release
+    │       ├── Release.gpg
+    │       └── main
+    │           ├── Contents-amd64.gz
+    │           └── binary-amd64
+    │               ├── Packages
+    │               ├── Packages.bz2
+    │               ├── Packages.gz
+    │               └── Release
+    └── pool
+        └── main
+            └── o
+                └── openvpn
+                    └── openvpn_2.7-1716445794_amd64.deb
+
+10 directories, 10 files
+```
+
+Each distro's packages are completely isolated from other distros' packages.

--- a/buildbot-host/aptly/aptly.conf
+++ b/buildbot-host/aptly/aptly.conf
@@ -1,0 +1,44 @@
+{
+  "rootDir": "/var/lib/aptly",
+  "downloadConcurrency": 4,
+  "downloadSpeedLimit": 0,
+  "architectures": ["amd64"],
+  "dependencyFollowSuggests": false,
+  "dependencyFollowRecommends": false,
+  "dependencyFollowAllVariants": false,
+  "dependencyFollowSource": false,
+  "dependencyVerboseResolve": false,
+  "gpgDisableSign": false,
+  "gpgDisableVerify": false,
+  "gpgProvider": "gpg2",
+  "downloadSourcePackages": false,
+  "skipLegacyPool": true,
+  "ppaDistributorID": "ubuntu",
+  "ppaCodename": "",
+  "FileSystemPublishEndpoints": {
+    "debian-12": {
+      "rootDir": "/var/lib/aptly/public/debian-12",
+      "linkMethod": "copy",
+      "verifyMethod": "md5"
+    },
+    "debian-11": {
+      "rootDir": "/var/lib/aptly/public/debian-11",
+      "linkMethod": "copy",
+      "verifyMethod": "md5"
+    },
+    "ubuntu-2204": {
+      "rootDir": "/var/lib/aptly/public/ubuntu-2204",
+      "linkMethod": "copy",
+      "verifyMethod": "md5"
+    },
+    "ubuntu-2404": {
+      "rootDir": "/var/lib/aptly/public/ubuntu-2404",
+      "linkMethod": "copy",
+      "verifyMethod": "md5"
+    }
+  },
+  "enableMetricsEndpoint": false,
+  "logLevel": "debug",
+  "logFormat": "default",
+  "serveInAPIMode": true
+}

--- a/buildbot-host/aptly/fpm/after-install.sh
+++ b/buildbot-host/aptly/fpm/after-install.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+#
+SERVICE="publish-incoming-debian-snapshots.service"
+
+systemctl daemon-reload
+systemctl enable $SERVICE
+systemctl start $SERVICE

--- a/buildbot-host/aptly/fpm/after-remove.sh
+++ b/buildbot-host/aptly/fpm/after-remove.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+#
+systemctl daemon-reload

--- a/buildbot-host/aptly/fpm/after-upgrade.sh
+++ b/buildbot-host/aptly/fpm/after-upgrade.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+#
+SERVICE="publish-incoming-debian-snapshots.service"
+
+systemctl daemon-reload
+systemctl is-active $SERVICE > /dev/null && systemctl restart $SERVICE

--- a/buildbot-host/aptly/fpm/package.sh
+++ b/buildbot-host/aptly/fpm/package.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+#
+# Create "publish-incoming-debian-snapshots" Debian package
+#
+set -e
+
+SRC=$(dirname -- "$( readlink -f -- "$0"; )";)/..
+FILES_FOUND=yes
+
+if [ "x${SRC}" = "x" ]; then
+  echo "ERROR: unable to determine source directory!"
+  exit 1
+fi
+
+for FILE in \
+    "${SRC}/publish-debian-snapshot.sh" \
+    "${SRC}/publish-incoming-debian-snapshots.sh" \
+    "${SRC}/publish-incoming-debian-snapshots.service" \
+    "${SRC}/aptly.conf"
+do
+    if ! [ -r "${FILE}" ]; then
+        echo "ERROR: ${FILE} missing, cannot build!"
+	FILES_FOUND=no
+    fi
+done
+
+if [ "${FILES_FOUND}" = "no" ]; then
+    exit 1
+fi
+
+# Construct the package layout
+rm -rf "${SRC}/target"
+mkdir -vp "${SRC}/target/etc/systemd/system"
+mkdir -vp "${SRC}/target/usr/local/bin"
+
+cp -v "${SRC}/publish-debian-snapshot.sh" "${SRC}/target/usr/local/bin/"
+cp -v "${SRC}/publish-incoming-debian-snapshots.sh" "${SRC}/target/usr/local/bin/"
+cp -v "${SRC}/publish-incoming-debian-snapshots.service" "${SRC}/target/etc/systemd/system/"
+cp -v "${SRC}/aptly.conf" "${SRC}/target/etc/"
+
+fpm \
+  -t deb \
+  --force \
+  --name "publish-incoming-debian-snapshots" \
+  --description "Publish new Debian and Ubuntu packages created by Buildbot workers in aptly repositories" \
+  --license "BSD-2-Clause" \
+  --vendor "OpenVPN project" \
+  --maintainer "Samuli Seppänen <samuli.seppanen@gmail.com>" \
+  --url "https://github.com/OpenVPN/openvpn-buildbot" \
+  --version "0.10.0" \
+  --iteration "1" \
+  --after-install "${SRC}/fpm/after-install.sh" \
+  --after-upgrade "${SRC}/fpm/after-upgrade.sh" \
+  --after-remove "${SRC}/fpm/after-remove.sh" \
+  --deb-no-default-config-files \
+  -d 'aptly >= 1.5.0' \
+  -d 'inotify-tools >= 3.22.0' \
+  -d 'gnupg >= 2.2.0' \
+  -d 'pcregrep >= 2' \
+  -C "${SRC}/target" \
+  -s dir .
+
+rm -rf "${SRC}/target"

--- a/buildbot-host/aptly/fpm/setup-fpm.sh
+++ b/buildbot-host/aptly/fpm/setup-fpm.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+#
+# Install fpm and its dependencies
+#
+set -e
+apt-get update
+apt-get -y install ruby binutils
+gem install fpm

--- a/buildbot-host/aptly/publish-debian-snapshot.sh
+++ b/buildbot-host/aptly/publish-debian-snapshot.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+#
+# Publish a package to an aptly repository
+#
+set -e
+
+usage() {
+    echo "Usage: publish-debian-snapshot.sh -p <package> -f <passphrase-file> [-s <hook script>] [-h]"
+    echo
+    echo "Options:"
+    echo "    -p    the debian (.deb) package to publish"
+    echo "    -f    GPG passphrase file"
+    echo "    -s    hook script to run"
+    echo "    -h    show this help"
+    echo
+    echo "The repository name (e.g. debian-12) is passed to the hook script as the first"
+    echo "parameter."
+    echo
+    exit 2
+}
+
+HOOK_SCRIPT=""
+
+while getopts 'f:p:s:h' arg
+do
+  case $arg in
+    p) PACKAGE=$OPTARG ;;
+    f) PASSPHRASE_FILE=$OPTARG ;;
+    s) HOOK_SCRIPT=$OPTARG ;;
+    h) usage ;;
+    *) usage
+  esac
+done
+
+# Ensure that mandatory parameters have been defined
+if [ "x${PACKAGE}" = "x" ] || [ "x${PASSPHRASE_FILE}" = "x" ]; then
+    usage
+fi
+
+# Only accept absolute paths
+echo $PACKAGE|grep "^/" > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "ERROR: must provide absolute path to the package!"
+    usage
+fi
+
+if ! [ -r "${PACKAGE}" ]; then
+    echo "ERROR: package ${PACKAGE} not found!"
+    exit 1
+fi
+
+if ! [ -r "${PASSPHRASE_FILE}" ]; then
+    echo "ERROR: passphrase file ${PASSPHRASE_FILE} not found!"
+    exit 1
+fi
+
+if [ "x${HOOK_SCRIPT}" != "x" ] && ! [ -r "${HOOK_SCRIPT}" ]; then
+    echo "ERROR: hook script ${HOOK_SCRIPT} not found!"
+    exit 1
+fi
+
+MATCH='/buildbot-worker-([[:alpha:]]+-[[:digit:]]+)/'
+REPO=$(echo "${PACKAGE}"|pcregrep -o1 $MATCH) || true
+
+if [ "x${REPO}" = "x" ]; then
+    echo "ERROR: unable to determine repository name from package file path:"
+    echo
+    echo $PACKAGE
+    echo
+    echo "Ensure that file path matches pattern ${MATCH}"
+    exit 1
+fi
+
+echo "Publishing $(basename $PACKAGE) in repository ${REPO}"
+
+aptly repo add $REPO $PACKAGE
+
+PUBLISH_PARAMS="-batch -passphrase-file=$PASSPHRASE_FILE $REPO filesystem:$REPO:."
+aptly publish repo $PUBLISH_PARAMS 2> /dev/null || aptly publish update $PUBLISH_PARAMS
+
+# Run the hook script if one is defined
+if [ "x${HOOK_SCRIPT}" != "x" ]; then
+    $HOOK_SCRIPT $REPO
+fi

--- a/buildbot-host/aptly/publish-incoming-debian-snapshots.service
+++ b/buildbot-host/aptly/publish-incoming-debian-snapshots.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Publish new Debian and Ubuntu packages created by Buildbot workers in aptly repositories
+After=multi-user.target
+
+[Service]
+ExecStart=/usr/local/bin/publish-incoming-debian-snapshots.sh
+Type=simple
+
+[Install]
+WantedBy=multi-user.target

--- a/buildbot-host/aptly/publish-incoming-debian-snapshots.sh
+++ b/buildbot-host/aptly/publish-incoming-debian-snapshots.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+#
+VOLUMES="/var/lib/docker/volumes"
+INCLUDE='buildbot-worker-[[:alpha:]]+-[[:digit:]]+/_data/openvpn_2.*\.deb'
+PUBLISH_SCRIPT="publish-debian-snapshot.sh"
+PASSWORD_FILE="/etc/aptly.pass"
+APTLY_ROOTDIR="/var/lib/aptly"
+HOOK_SCRIPT="/usr/local/bin/publish-debian-snapshot-hook.sh"
+
+# Enable hook script, if any
+HOOK_PARAMS=""
+if [ -x "${HOOK_SCRIPT}" ]; then
+    HOOK_PARAMS="-s ${HOOK_SCRIPT}"
+fi
+
+which $PUBLISH_SCRIPT > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "ERROR: publish-debian-snapshot.sh not found in PATH"
+    exit 1
+fi
+
+if ! [ -r "${PASSWORD_FILE}" ]; then
+    echo "ERROR: GnuPG password file ${PASSWORD_FILE} not found!"
+    exit 1
+fi
+
+# Ensure that aptly repo configuration is up-to-date
+test -d $APTLY_ROOTDIR || mkdir -p $APTLY_ROOTDIR
+
+# Create aptly repositories for each matching Buildbot worker Docker volume
+MATCH='buildbot-worker-((debian|ubuntu)-[[:digit:]]+)'
+for VOLUME in $(ls $VOLUMES|grep -E $MATCH); do
+    DISTRO=$(echo $VOLUME|pcregrep -o1 $MATCH)
+    aptly repo show $DISTRO > /dev/null 2>&1 || aptly repo create -architectures="amd64" -comment="Buildbot-generated packages for ${DISTRO}" -component="main" -distribution="${DISTRO}" $DISTRO
+done
+
+inotifywait --format "%w%f" --event CREATE --monitor --recursive --include "${INCLUDE}" "${VOLUMES}" |\
+    while read PACKAGE; do
+        $PUBLISH_SCRIPT -p $PACKAGE -f $PASSWORD_FILE $HOOK_PARAMS
+    done

--- a/buildbot-host/aptly/setup-aptly-ubuntu.sh
+++ b/buildbot-host/aptly/setup-aptly-ubuntu.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+#
+# Set up aptly on Ubuntu
+#
+set -e
+
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A0546A43624A8331
+echo "deb http://repo.aptly.info/ squeeze main" > /etc/apt/sources.list.d/aptly.list
+apt-get update
+apt-get install -y aptly

--- a/buildbot-host/buildmaster/debian-package.sh
+++ b/buildbot-host/buildmaster/debian-package.sh
@@ -37,3 +37,4 @@ mv debian-changelog openvpn-$SV/debian/changelog
 cd openvpn-$SV
 dpkg-buildpackage -d -S -uc
 dpkg-buildpackage -b
+cp -v ../*.deb /home/buildbot/


### PR DESCRIPTION
The first two commits allow speeding up buildbot testing by disabling unnecessary build types. Those could be split into a different PR easily.

The last two commits are related to Debian/Ubuntu snapshot publishing. The publishing process seems to work reliably but has not been tested outside of my own private (Ubuntu 23.10) buildbot instance.

How this setup works is explained in detail in [buildbot-host/aptly/README.md](https://github.com/mattock/openvpn-buildbot/blob/publish_debian_snapshots/buildbot-host/aptly/README.md).