### PR TITLE
Allow skipping build types

### DIFF
--- a/buildbot-host/buildmaster/master-default.ini
+++ b/buildbot-host/buildmaster/master-default.ini
@@ -24,6 +24,7 @@ repo_url=https://github.com/OpenVPN/openvpn.git
 main_branch=master
 release_branch=release/2.6
 run_tclient_tests=False
+run_code_check=False
 # Seconds to wait for new commits before launching the builds. Use None to
 # or 0 to build immediately on commit.
 tree_stable_timer=0

--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -261,13 +261,13 @@ for scheduler in scheduler_names:
 
 # Load configuration options used for packaging, connectivity testing and compile tests
 build_and_test_config_opt_combos = json.loads(
-    master_config.get("openvpn", "build_and_test_config_opt_combos")
+    master_config.get("openvpn", "build_and_test_config_opt_combos", fallback="[]")
 )
 compile_config_opt_combos = json.loads(
-    master_config.get("openvpn", "compile_config_opt_combos")
+    master_config.get("openvpn", "compile_config_opt_combos", fallback="[]")
 )
 packaging_config_opt_combos = json.loads(
-    master_config.get("openvpn", "packaging_config_opt_combos")
+    master_config.get("openvpn", "packaging_config_opt_combos", fallback="[]")
 )
 
 c["secretsProviders"] = [

--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -219,6 +219,7 @@ openvpn_main_branch = master_config.get("openvpn", "main_branch")
 openvpn_release_branch = master_config.get("openvpn", "release_branch")
 openvpn_run_tserver_null_tests = master_config.getboolean("openvpn", "run_tserver_null_tests")
 openvpn_run_tclient_tests = master_config.getboolean("openvpn", "run_tclient_tests")
+openvpn_run_code_check = master_config.getboolean("openvpn", "run_code_check")
 otst = master_config.get("openvpn", "tree_stable_timer")
 openvpn_tree_stable_timer = None if otst == "None" else int(otst)
 
@@ -488,20 +489,21 @@ ccache = {
 factories = {}
 
 # OpenVPN 2 Uncrustify code check
-factory = util.BuildFactory()
-factory = openvpnAddUncrustifyStepsToBuildFactory(factory, ccache)
-factory_name = "openvpn-code-check"
-factories.update(
-    {
-        factory_name: {
-            "factory": factory,
-            "os": "unix",
-            "types": ["code-check", "openvpn"],
-            "schedulers": ["openvpn_main", "openvpn_release"],
+if openvpn_run_code_check:
+    factory = util.BuildFactory()
+    factory = openvpnAddUncrustifyStepsToBuildFactory(factory, ccache)
+    factory_name = "openvpn-code-check"
+    factories.update(
+        {
+            factory_name: {
+                "factory": factory,
+                "os": "unix",
+                "types": ["code-check", "openvpn"],
+                "schedulers": ["openvpn_main", "openvpn_release"],
+            }
         }
-    }
-)
-del factory
+    )
+    del factory
 
 # OpenVPN 2 smoketest using default configure options
 factory = util.BuildFactory()


### PR DESCRIPTION
Previously every build type (e.g. build and test, compile, package, code check) had to be defined or the config parser choked and the buildmaster failed to start. Now it does not fail, but just skips the builds that are not defined. This speeds up developing buildbot code considerably as one does not have to wait for all the irrelevant builds to finish or manually stop them.