### PR TITLE
Fix openvpn3-linux builds

### DIFF
--- a/buildbot-host/buildbot-worker-alpine-3/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-alpine-3/Dockerfile.base
@@ -1,5 +1,6 @@
 ARG IMAGE=alpine:3.18.4
 ARG DEPS_SH=install-openvpn-build-deps-alpine.sh
 ARG MY_NAME="buildbot-worker-alpine-3"
-ARG MY_VERSION="v1.0.3"
+ARG MY_VERSION="v1.1.0"
 ARG ASIO_REF="asio-1-18-2"
+ARG INSTALL_GDBUSPP="yes"

--- a/buildbot-host/buildbot-worker-arch/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-arch/Dockerfile.base
@@ -2,5 +2,6 @@ ARG IMAGE=docker.io/library/archlinux:latest
 ARG DEPS_SH=install-openvpn-build-deps-arch.sh
 ARG MY_NAME="buildbot-worker-arch"
 ARG PIP_INSTALL_OPTS="--break-system-packages"
-ARG MY_VERSION="v1.0.2"
+ARG MY_VERSION="v1.1.0"
 ARG ASIO_REF="master"
+ARG INSTALL_GDBUSPP="yes"

--- a/buildbot-host/buildbot-worker-debian-10/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-debian-10/Dockerfile.base
@@ -1,5 +1,6 @@
 ARG IMAGE=debian:10
 ARG DEPS_SH=install-openvpn-build-deps-ubuntu.sh
 ARG MY_NAME="buildbot-worker-debian-10"
-ARG MY_VERSION="v1.0.2"
+ARG MY_VERSION="v1.0.3"
 ARG ASIO_REF="asio-1-18-2"
+ARG INSTALL_GDBUSPP="no"

--- a/buildbot-host/buildbot-worker-debian-11/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-debian-11/Dockerfile.base
@@ -1,5 +1,6 @@
 ARG IMAGE=debian:11
 ARG DEPS_SH=install-openvpn-build-deps-ubuntu.sh
 ARG MY_NAME="buildbot-worker-debian-11"
-ARG MY_VERSION="v1.0.2"
+ARG MY_VERSION="v1.0.3"
 ARG ASIO_REF="asio-1-18-2"
+ARG INSTALL_GDBUSPP="no"

--- a/buildbot-host/buildbot-worker-debian-12/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-debian-12/Dockerfile.base
@@ -2,5 +2,6 @@ ARG IMAGE=debian:12
 ARG DEPS_SH=install-openvpn-build-deps-ubuntu.sh
 ARG MY_NAME="buildbot-worker-debian-12"
 ARG PIP_INSTALL_OPTS="--break-system-packages"
-ARG MY_VERSION="v1.0.0"
+ARG MY_VERSION="v1.1.0"
 ARG ASIO_REF="asio-1-18-2"
+ARG INSTALL_GDBUSPP="yes"

--- a/buildbot-host/buildbot-worker-debian-unstable/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-debian-unstable/Dockerfile.base
@@ -2,5 +2,6 @@ ARG IMAGE=debian:unstable
 ARG DEPS_SH=install-openvpn-build-deps-ubuntu.sh
 ARG MY_NAME="buildbot-worker-debian-unstable"
 ARG PIP_INSTALL_OPTS="--break-system-packages"
-ARG MY_VERSION="v1.0.2"
+ARG MY_VERSION="v1.1.0"
 ARG ASIO_REF="master"
+ARG INSTALL_GDBUSPP="yes"

--- a/buildbot-host/buildbot-worker-fedora-39/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-fedora-39/Dockerfile.base
@@ -1,5 +1,6 @@
 ARG IMAGE=fedora:39
 ARG DEPS_SH=install-openvpn-build-deps-fedora.sh
 ARG MY_NAME="buildbot-worker-fedora-39"
-ARG MY_VERSION="v1.0.0"
+ARG MY_VERSION="v1.1.0"
 ARG ASIO_REF="asio-1-18-2"
+ARG INSTALL_GDBUSPP="yes"

--- a/buildbot-host/buildbot-worker-fedora-40/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-fedora-40/Dockerfile.base
@@ -1,5 +1,6 @@
 ARG IMAGE=fedora:40
 ARG DEPS_SH=install-openvpn-build-deps-fedora.sh
 ARG MY_NAME="buildbot-worker-fedora-40"
-ARG MY_VERSION="v1.0.0"
+ARG MY_VERSION="v1.1.0"
 ARG ASIO_REF="asio-1-18-2"
+ARG INSTALL_GDBUSPP="yes"

--- a/buildbot-host/buildbot-worker-fedora-rawhide/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-fedora-rawhide/Dockerfile.base
@@ -1,5 +1,6 @@
 ARG IMAGE=fedora:rawhide
 ARG DEPS_SH=install-openvpn-build-deps-fedora.sh
 ARG MY_NAME="buildbot-worker-fedora-rawhide"
-ARG MY_VERSION="v1.0.2"
+ARG MY_VERSION="v1.1.0"
 ARG ASIO_REF="asio-1-18-2"
+ARG INSTALL_GDBUSPP="yes"

--- a/buildbot-host/buildbot-worker-opensuse-leap-15/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-opensuse-leap-15/Dockerfile.base
@@ -1,5 +1,6 @@
 ARG IMAGE=opensuse/leap:15
 ARG DEPS_SH=install-openvpn-build-deps-opensuse-leap.sh
 ARG MY_NAME="buildbot-worker-opensuse-leap-15"
-ARG MY_VERSION="v1.0.2"
+ARG MY_VERSION="v1.0.3"
 ARG ASIO_REF="asio-1-18-2"
+ARG INSTALL_GDBUSPP="no"

--- a/buildbot-host/buildbot-worker-ubuntu-2004/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-ubuntu-2004/Dockerfile.base
@@ -1,5 +1,6 @@
 ARG IMAGE=ubuntu:20.04
 ARG DEPS_SH=install-openvpn-build-deps-ubuntu.sh
 ARG MY_NAME="buildbot-worker-ubuntu-2004"
-ARG MY_VERSION="v1.0.2"
+ARG MY_VERSION="v1.0.3"
 ARG ASIO_REF="asio-1-18-2"
+ARG INSTALL_GDBUSPP="no"

--- a/buildbot-host/buildbot-worker-ubuntu-2204/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-ubuntu-2204/Dockerfile.base
@@ -1,5 +1,6 @@
 ARG IMAGE=ubuntu:22.04
 ARG DEPS_SH=install-openvpn-build-deps-ubuntu.sh
 ARG MY_NAME="buildbot-worker-ubuntu-2204"
-ARG MY_VERSION="v1.0.1"
+ARG MY_VERSION="v1.0.2"
 ARG ASIO_REF="asio-1-18-2"
+ARG INSTALL_GDBUSPP="no"

--- a/buildbot-host/buildbot-worker-ubuntu-2404/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-ubuntu-2404/Dockerfile.base
@@ -2,5 +2,6 @@ ARG IMAGE=ubuntu:24.04
 ARG DEPS_SH=install-openvpn-build-deps-ubuntu.sh
 ARG MY_NAME="buildbot-worker-ubuntu-2404"
 ARG PIP_INSTALL_OPTS="--break-system-packages"
-ARG MY_VERSION="v1.0.0"
+ARG MY_VERSION="v1.1.0"
 ARG ASIO_REF="asio-1-18-2"
+ARG INSTALL_GDBUSPP="yes"

--- a/buildbot-host/buildmaster/openvpn3-linux/common_linux_steps.cfg
+++ b/buildbot-host/buildmaster/openvpn3-linux/common_linux_steps.cfg
@@ -22,10 +22,7 @@ def openvpn3LinuxAddCommonLinuxStepsToBuildFactory(factory, config_opts):
 
     factory.addStep(
         steps.ShellCommand(
-            command=[util.Property("openvpn3_linux_command_prefix")]
-            + ["./configure"]
-            + config_opts
-            + [util.Property("openvpn3_linux_extra_config_opts", default=[])],
+            command=["meson", "setup", "--prefix=/usr", "_builddir"],
             name="configure",
             description="configuring",
             descriptionDone="configuring",
@@ -34,7 +31,7 @@ def openvpn3LinuxAddCommonLinuxStepsToBuildFactory(factory, config_opts):
 
     factory.addStep(
         steps.ShellCommand(
-            command=[util.Property("openvpn3_linux_command_prefix")] + ["make"],
+            command=["meson", "compile", "-C", "_builddir"],
             name="building",
             description="building",
             descriptionDone="building",

--- a/buildbot-host/buildmaster/worker-default.ini
+++ b/buildbot-host/buildmaster/worker-default.ini
@@ -29,6 +29,7 @@ openvpn3_linux_command_prefix=["/bin/sh", "--login", "-c"]
 openvpn3_linux_extra_config_opts=--disable-unit-tests
 # asio in CentOS 7 is too old to work with openvpn3
 enable_openvpn3_builds=false
+enable_openvpn3-linux_builds=false
 enable_ovpn-dco_builds=false
 openvpn_extra_config_opts=--disable-dco
 enable_debian_builds=false

--- a/buildbot-host/buildmaster/worker-default.ini
+++ b/buildbot-host/buildmaster/worker-default.ini
@@ -41,36 +41,38 @@ enable_ovpn-dco_builds=false
 openvpn_extra_config_opts=--disable-dco
 # xxhash too old
 enable_openvpn3_builds=false
+enable_openvpn3-linux_builds=false
 
 [debian-11]
-image=openvpn_community/buildbot-worker-debian-11:v1.0.2
+image=openvpn_community/buildbot-worker-debian-11:v1.0.3
+enable_openvpn3-linux_builds=false
 
 [debian-12]
-image=openvpn_community/buildbot-worker-debian-12:v1.0.0
+image=openvpn_community/buildbot-worker-debian-12:v1.1.0
 
 [debian-unstable]
-image=openvpn_community/buildbot-worker-debian-unstable:v1.0.2
+image=openvpn_community/buildbot-worker-debian-unstable:v1.1.0
 
 [arch]
-image=openvpn_community/buildbot-worker-arch:v1.0.2
+image=openvpn_community/buildbot-worker-arch:v1.1.0
 enable_debian_builds=false
 
 [alpine]
-image=openvpn_community/buildbot-worker-alpine-3:v1.0.3
+image=openvpn_community/buildbot-worker-alpine-3:v1.1.0
 enable_debian_builds=false
 enable_openvpn3_builds=false
 enable_openvpn3-linux_builds=false
 
 [fedora-39]
-image=openvpn_community/buildbot-worker-fedora-39:v1.0.0
+image=openvpn_community/buildbot-worker-fedora-39:v1.1.0
 enable_debian_builds=false
 
 [fedora-40]
-image=openvpn_community/buildbot-worker-fedora-40:v1.0.0
+image=openvpn_community/buildbot-worker-fedora-40:v1.1.0
 enable_debian_builds=false
 
 #[fedora-rawhide]
-#image=openvpn_community/buildbot-worker-fedora-rawhide:v1.0.2
+#image=openvpn_community/buildbot-worker-fedora-rawhide:v1.1.0
 #enable_debian_builds=false
 
 [opensuse-leap-15]
@@ -78,21 +80,24 @@ image=openvpn_community/buildbot-worker-opensuse-leap-15:v1.0.2
 enable_debian_builds=false
 # Kernel headers are not usable on this platform out of the box
 enable_ovpn-dco_builds=false
+enable_openvpn3-linux_builds=false
 openvpn_extra_config_opts=--disable-dco
 
 [ubuntu-2004]
-image=openvpn_community/buildbot-worker-ubuntu-2004:v1.0.2
+image=openvpn_community/buildbot-worker-ubuntu-2004:v1.0.3
+enable_openvpn3-linux_builds=false
 
 #[ubuntu-2004-vm-static]
 #type=normal
 #ostype=unix
 
 [ubuntu-2204]
-image=openvpn_community/buildbot-worker-ubuntu-2204:v1.0.1
+image=openvpn_community/buildbot-worker-ubuntu-2204:v1.0.2
 enable_code-check_builds=true
+enable_openvpn3-linux_builds=false
 
 [ubuntu-2404]
-image=openvpn_community/buildbot-worker-ubuntu-2404:v1.0.0
+image=openvpn_community/buildbot-worker-ubuntu-2404:v1.1.0
 
 #[macos-amd64]
 #type=normal

--- a/buildbot-host/scripts/install-buildbot.sh
+++ b/buildbot-host/scripts/install-buildbot.sh
@@ -7,7 +7,14 @@ set -ex
 BUILDBOT_VERSION=3.11.1
 
 # hardcode cryptography version since newer don't work on CentOS 7
-pip3 install $PIP_INSTALL_OPTS --upgrade pip
+
+# Upgrading pip may or may not work. On Ubuntu 24.04 it may fail with
+#
+# "ERROR: Cannot uninstall pip 24.0, RECORD file not found. Hint: The package was installed by debian."
+#
+# Try and if it fails just keep on going
+#
+pip3 install $PIP_INSTALL_OPTS --upgrade pip || true
 pip --no-cache-dir install $PIP_INSTALL_OPTS cryptography==37.0.4
 pip --no-cache-dir install $PIP_INSTALL_OPTS twisted[tls]
 pip --no-cache-dir install $PIP_INSTALL_OPTS buildbot_worker==$BUILDBOT_VERSION

--- a/buildbot-host/scripts/install-gdbuspp.sh
+++ b/buildbot-host/scripts/install-gdbuspp.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# Install GDBus++ :: glib2 D-Bus C++ interface
+#
+# This is a prerequisite for building openvpn3-linux. We don't use "set -e" here
+# because meson exit code may be non-zero (e.g. 130) even if all went well.
+#
+if [ "${INSTALL_GDBUSPP}" = "yes" ]; then
+    git clone https://codeberg.org/OpenVPN/gdbuspp.git
+    cd gdbuspp
+    meson setup --prefix=/usr _builddir
+    cd _builddir
+    meson compile
+    meson install
+    ldconfig
+fi

--- a/buildbot-host/scripts/install-openvpn-build-deps-alpine.sh
+++ b/buildbot-host/scripts/install-openvpn-build-deps-alpine.sh
@@ -11,7 +11,7 @@ ccache \
 cmake \
 cmocka-dev \
 curl \
-dbus-cpp-dev \
+dbus-dev \
 fping \
 g++ \
 git \

--- a/buildbot-host/scripts/install-openvpn-build-deps-alpine.sh
+++ b/buildbot-host/scripts/install-openvpn-build-deps-alpine.sh
@@ -11,9 +11,11 @@ ccache \
 cmake \
 cmocka-dev \
 curl \
+dbus-cpp-dev \
 fping \
 g++ \
 git \
+glib-dev \
 iproute2 \
 jsoncpp-dev \
 libcap-ng-dev \
@@ -28,9 +30,13 @@ lz4-dev \
 lzo-dev \
 make \
 mbedtls-dev \
+meson \
 net-tools \
 pkgconf \
 procps \
+protobuf \
+protobuf-dev \
+protobuf-c-dev \
 opensc-dev \
 openssh-client \
 openssl-dev \

--- a/buildbot-host/scripts/install-openvpn-build-deps-arch.sh
+++ b/buildbot-host/scripts/install-openvpn-build-deps-arch.sh
@@ -34,12 +34,14 @@ lz4 \
 lzo \
 make \
 mbedtls2 \
+meson \
 openssh \
 openssl \
 pam \
 pkcs11-helper \
 pkgconf \
 polkit \
+protobuf \
 python \
 python-gobject \
 python-pip \

--- a/buildbot-host/scripts/install-openvpn-build-deps-fedora.sh
+++ b/buildbot-host/scripts/install-openvpn-build-deps-fedora.sh
@@ -10,7 +10,7 @@ automake \
 bzip2 \
 ccache \
 cmake \
-dbus-c++-devel \
+dbus-devel \
 fping \
 gcc \
 gcc-c++ \

--- a/buildbot-host/scripts/install-openvpn-build-deps-fedora.sh
+++ b/buildbot-host/scripts/install-openvpn-build-deps-fedora.sh
@@ -10,6 +10,7 @@ automake \
 bzip2 \
 ccache \
 cmake \
+dbus-c++-devel \
 fping \
 gcc \
 gcc-c++ \
@@ -31,12 +32,16 @@ lzo-devel \
 kernel-devel \
 make \
 mbedtls-devel \
+meson \
 openssl-devel \
 pam-devel \
 pkcs11-helper-devel \
 pkgconfig \
 polkit \
 procps \
+protobuf \
+protobuf-compiler \
+protobuf-devel \
 python3-devel \
 python3-dbus \
 python3-docutils \

--- a/buildbot-host/scripts/install-openvpn-build-deps-ubuntu.sh
+++ b/buildbot-host/scripts/install-openvpn-build-deps-ubuntu.sh
@@ -35,7 +35,7 @@ libasio-dev \
 libcap-dev \
 libcap-ng-dev \
 libcmocka-dev \
-libdbus-c++-dev \
+libdbus-1-dev \
 libdebconfclient0 \
 libdpkg-perl \
 libprotobuf-dev \

--- a/buildbot-host/scripts/install-openvpn-build-deps-ubuntu.sh
+++ b/buildbot-host/scripts/install-openvpn-build-deps-ubuntu.sh
@@ -35,8 +35,10 @@ libasio-dev \
 libcap-dev \
 libcap-ng-dev \
 libcmocka-dev \
+libdbus-c++-dev \
 libdebconfclient0 \
 libdpkg-perl \
+libprotobuf-dev \
 libfakeroot \
 libfile-stripnondeterminism-perl \
 libglib2.0-dev \
@@ -55,11 +57,13 @@ libtinyxml2-dev \
 libxml2-utils \
 libxxhash-dev \
 make \
+meson \
 net-tools \
 openssh-client \
 pkg-config \
 po-debconf \
 policykit-1 \
+protobuf-compiler \
 python3 \
 python3-docutils \
 python3-dev \

--- a/buildbot-host/snippets/Dockerfile.common
+++ b/buildbot-host/snippets/Dockerfile.common
@@ -11,6 +11,14 @@ RUN set -ex; \
     /buildbot/${DEPS_SH}; \
     rm -f ${DEPS_SH}
 
+# Install gdbuspp, which is a dependency of openvpn3-linux
+ARG INSTALL_GDBUSPP
+COPY scripts/install-gdbuspp.sh /buildbot/
+RUN set -x; \
+    /buildbot/install-gdbuspp.sh; \
+    rm -f install-gdbuspp.sh; \
+    rm -rf /buildbot/gdbuspp
+
 # Install buildbot
 ARG MY_NAME
 ARG PIP_INSTALL_OPTS
@@ -23,4 +31,3 @@ COPY buildbot.tac /buildbot/
 RUN mkdir -p /home/buildbot
 
 CMD ["twistd", "--pidfile=", "--nodaemon", "--python=buildbot.tac"]
-


### PR DESCRIPTION
This PR fixes openvpn3-linux builds insofar as it can be done with reasonable effort.

Several older distros were unable to (easily) compile gdbuspp (openvpn3-linux dependency) or had too old meson (buildsystem) version in the repositories. Fixing those older operating systems would have required lots of additional work, probably for little gain.

With the exception of Alpine Linux all the more recent systems compile just fine. There some library version may be wrong which prevents openvpn3-linux from compiling despite the setup phase succeeding. 

I bumped container image versions by one minor version up (e.g. 1.0.3 -> 1.1.0) for those distros where openvpn3-linux could be compiled. For the rest I added one to the patchlevel (e.g. 1.0.2 -> 1.0.3) because the images are no exactly the same as before due to extra (unused) dependencies such as "meson" having been installed on them.

I encountered an unrelated issue on Fedora Rawhide: when the container image is built from scratch, Buildmaster is unable to instantiate it because it hits this error when launching the Buildbot worker (i.e. twisted):

```
--- snip ---
  File "/buildbot_venv/lib/python3.9/site-packages/buildbot/process/buildstep.py", line 860, in runCommand
    res = yield command.run(self, self.remote, self.build.builder.name)
  File "/buildbot_venv/lib/python3.9/site-packages/buildbot/process/remotecommand.py", line 167, in _finished
    yield self.remoteComplete(failure)
buildbot.process.remotecommand.RemoteException: b'buildbot_worker.exceptions.AbandonChain': (-1, "Got exception (No module named 'pipes')")
Traceback (most recent call last):
Failure: buildbot_worker.exceptions.AbandonChain: (-1, "Got exception (No module named 'pipes')")
```