### PR TITLE
windows-server/msibuild: Add gcloud CLI and jsign.jar

### DIFF
--- a/jenkins/windows-server/build/.gitignore
+++ b/jenkins/windows-server/build/.gitignore
@@ -2,3 +2,5 @@ administrators_authorized_keys
 build-and-package-env.ps1
 customerCA.crt
 signingCert.p7b
+signingCert.pem
+clientLibraryConfig.json

--- a/jenkins/windows-server/msibuild.pkr.hcl
+++ b/jenkins/windows-server/msibuild.pkr.hcl
@@ -1,11 +1,11 @@
 build {
   source "amazon-ebs.windows-server-2019" {
     name     = "msibuild-windows-server-2019-2.5"
-    ami_name = "msibuild-windows-server-2019-2.5-4"
+    ami_name = "msibuild-windows-server-2019-2.5-5"
   }
   source "amazon-ebs.windows-server-2022" {
     name     = "msibuild-windows-server-2022-2.6"
-    ami_name = "msibuild-windows-server-2022-2.6-5"
+    ami_name = "msibuild-windows-server-2022-2.6-6"
   }
 
   provisioner "file" {
@@ -60,5 +60,8 @@ build {
   }
   provisioner "powershell" {
     inline = ["C:/Windows/Temp/scripts/aws-cloudhsm.ps1 -configfiles C:\\config -workdir C:\\buildbot\\msbuild"]
+  }
+  provisioner "powershell" {
+    inline = ["C:/Windows/Temp/scripts/jsign.ps1 -configfiles C:\\config -workdir C:\\buildbot\\msbuild"]
   }
 }

--- a/jenkins/windows-server/shared.pkr.hcl
+++ b/jenkins/windows-server/shared.pkr.hcl
@@ -44,7 +44,7 @@ variable "run_tags" {
 source "amazon-ebs" "windows-server-2019" {
   communicator         = "winrm"
   force_deregister     = true
-  instance_type        = "c5a.xlarge"
+  instance_type        = "c6a.xlarge"
   iam_instance_profile = var.windows_server_instance_profile
   region               = var.windows_server_ec2_region
   subnet_id            = var.windows_server_ec2_subnet
@@ -52,7 +52,7 @@ source "amazon-ebs" "windows-server-2019" {
   launch_block_device_mappings {
     device_name           = "/dev/sda1"
     volume_size           = 80
-    volume_type           = "gp2"
+    volume_type           = "gp3"
     delete_on_termination = true
   }
 
@@ -88,7 +88,7 @@ source "amazon-ebs" "windows-server-2019" {
 source "amazon-ebs" "windows-server-2022" {
   communicator         = "winrm"
   force_deregister     = true
-  instance_type        = "c5a.xlarge"
+  instance_type        = "c6a.xlarge"
   iam_instance_profile = var.windows_server_instance_profile
   region               = var.windows_server_ec2_region
   subnet_id            = var.windows_server_ec2_subnet
@@ -96,7 +96,7 @@ source "amazon-ebs" "windows-server-2022" {
   launch_block_device_mappings {
     device_name           = "/dev/sda1"
     volume_size           = 80
-    volume_type           = "gp2"
+    volume_type           = "gp3"
     delete_on_termination = true
   }
 

--- a/scripts/jsign.ps1
+++ b/scripts/jsign.ps1
@@ -1,0 +1,19 @@
+param ([string] $workdir,
+       [string] $configfiles)
+
+. C:\Windows\Temp\scripts\ps_support.ps1
+
+Write-Host "Setting up gcloud and jsign"
+
+& choco.exe install -y openjdk17
+CheckLastExitCode
+
+Invoke-WebRequest -Uri "https://dl.google.com/dl/cloudsdk/channels/rapid/GoogleCloudSDKInstaller.exe" -Outfile "C:\Windows\Temp\GoogleCloudSDKInstaller.exe"
+
+& "C:\Windows\Temp\GoogleCloudSDKInstaller.exe" /S /allusers
+CheckLastExitCode
+
+Invoke-WebRequest -Uri "https://github.com/ebourg/jsign/releases/download/6.0/jsign-6.0.jar" -Outfile "${workdir}/jsign.jar"
+
+Copy-Item "${configfiles}\signingCert.pem" "${workdir}" -Force
+Copy-Item "${configfiles}\clientLibraryConfig.json" "${workdir}" -Force


### PR DESCRIPTION
To allow us to use jsign with GoogleCloud KMS.

While here update instance specs to current
generation.