### PR TITLE
Windows and debian fixes

### DIFF
--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -598,7 +598,7 @@ for combo in packaging_config_opt_combos:
 
 # OpenVPN 2 Windows msbuild tests
 factory = util.BuildFactory()
-factory = openvpnAddCommonWindowsStepsToBuildFactory(factory, combo)
+factory = openvpnAddCommonWindowsStepsToBuildFactory(factory)
 factory_name = "msbuild"
 factories.update(
     {

--- a/buildbot-host/buildmaster/openvpn/common_windows_steps.cfg
+++ b/buildbot-host/buildmaster/openvpn/common_windows_steps.cfg
@@ -1,6 +1,6 @@
 # -*- python -*-
 # ex: set filetype=python:
-def openvpnAddCommonWindowsStepsToBuildFactory(factory, combo):
+def openvpnAddCommonWindowsStepsToBuildFactory(factory):
     # Set the work directory to "openvpn" instead of the default ("build"). This is needed
     # for MSI packaging which expects to find files from ..\..\openvpn.
     factory.workdir = "openvpn"

--- a/buildbot-host/scripts/install-openvpn-build-deps-ubuntu.sh
+++ b/buildbot-host/scripts/install-openvpn-build-deps-ubuntu.sh
@@ -62,7 +62,6 @@ net-tools \
 openssh-client \
 pkg-config \
 po-debconf \
-policykit-1 \
 protobuf-compiler \
 python3 \
 python3-docutils \
@@ -80,6 +79,9 @@ uuid-dev
 
 # Only for some distros
 $APT_INSTALL systemd-dev || true
+
+# policykit-1 is not available in more recent operating systems
+$APT_INSTALL policykit-1 || $APT_INSTALL polkitd pkexec
 
 # Install kernel headers for building ovpn-dco. Determining the correct package
 # name is challenging, so just try which ones install and which ones don't


### PR DESCRIPTION
This PR fixes Debian unstable builds (package name changes) and an issue with Windows build steps. In the longer run we may want to strip out the Windows building logic altogether if we don't use it.