### PR TITLE
Support external Docker hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,27 @@ image=openvpn_community/buildbot-worker-debian-11:v1.0.3
 
 The worker-default.ini file has example arm64 workers configured already.
 
+# Configuring build concurrency on Docker hosts
+
+The maximum number of concurrent builds needs to be configured in a JSON
+dictionary in master.ini:
+
+```
+[docker]
+max_builds={ "172.18.0.1": 4, "10.29.32.2": 4 }
+```
+
+The keys must be IP addresses or hostnames. Each key must be present in worker.ini
+as part of a docker_url. For example:
+
+```
+[DEFAULT]
+docker_url=tcp://172.18.0.1:2375
+
+[debian-11-arm64]
+docker_url=tcp://10.29.32.2:2375
+```
+
 # Development
 
 ## Defining image version and name

--- a/buildbot-host/buildmaster/master-default.ini
+++ b/buildbot-host/buildmaster/master-default.ini
@@ -65,6 +65,4 @@ branch=master
 tree_stable_timer=None
 
 [docker]
-# docker host needs to be defined without any quotes
-host=tcp://172.18.0.1:2375
 network=buildbot-net

--- a/buildbot-host/buildmaster/master-default.ini
+++ b/buildbot-host/buildmaster/master-default.ini
@@ -66,3 +66,4 @@ tree_stable_timer=None
 
 [docker]
 network=buildbot-net
+max_builds={ "172.18.0.1": 4, "10.29.32.2": 4 }

--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -4,7 +4,6 @@
 import configparser
 import json
 import treq
-import multiprocessing
 import os
 import random
 import re
@@ -13,6 +12,8 @@ import time
 from twisted.internet import defer
 from twisted.logger import Logger
 from twisted.python import failure
+
+from urllib.parse import urlparse
 
 from buildbot.plugins import *
 from buildbot.plugins import reporters, secrets, util
@@ -389,14 +390,16 @@ c["change_source"].append(
 
 c["builders"] = []
 
-# Limit concurrent builds across all latent docker workers
-cpus = multiprocessing.cpu_count()
-docker_build_lock = util.MasterLock("docker", maxCount=2 * cpus)
+# Limit concurrent builds on each Docker host
+max_builds = json.loads(master_config.get("docker", "max_builds"))
+docker_build_locks = {}
+
+for docker_host, maxcount in max_builds.items():
+    docker_build_locks[docker_host] = util.MasterLock(docker_host, maxCount=maxcount)
 
 # Only allow one docker worker to run t_client tests at the same time. This is
 # convenience feature to reduce the number of keys required for t_client tests.
 docker_tclient_lock = util.MasterLock("docker", maxCount=1)
-
 
 def getBuilderNameSuffix(combo):
     """Generate builder name suffix from configure options"""
@@ -742,12 +745,11 @@ for factory_name, factory in factories.items():
         if skip_build:
             continue
 
-        # Concurrent docker builds utilize a shared master lock in counting mode.
-        # In human-speak we only allow two concurrent Docker builders to run at
-        # any given time.
+        # Docker builds utilize a shared master lock in counting mode. Each Docker host
+        # has its own lock with a suitable concurrent build limit.
         if worker_config.get(worker_name, "type") == "latent_docker":
-            # Builder-level locks affect the entire build
-            locks = [docker_build_lock.access("counting")]
+            docker_host = urlparse(worker_config.get(worker_name, "docker_url")).hostname
+            locks = [docker_build_locks[docker_host].access("counting")]
         else:
             locks = None
 

--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -198,7 +198,6 @@ persistent_dir = os.path.expanduser(os.path.join(basedir, "persistent"))
 master_fqdn = master_config.get("master", "master_fqdn")
 buildbot_url = master_config.get("master", "buildbot_url")
 title_url = master_config.get("master", "title_url")
-docker_host = master_config.get("docker", "host", raw=True)
 docker_network = master_config.get("docker", "network")
 
 # Global email settings
@@ -285,6 +284,9 @@ for worker_name in worker_names:
     worker_persist = worker_config.get(worker_name, "persist")
     if worker_config.get(worker_name, "type") == "latent_docker":
         image = worker_config.get(worker_name, "image")
+        docker_url = worker_config.get(worker_name, "docker_url")
+        master_fqdn = worker_config.get(worker_name, "master_fqdn")
+
         c["workers"].append(
             worker.DockerLatentWorker(
                 worker_name,
@@ -294,10 +296,10 @@ for worker_name in worker_names:
                 properties={
                     "persist": worker_persist,
                 },
-                docker_host=docker_host,
+                docker_host=docker_url,
                 followStartupLogs=True,
                 image=image,
-                masterFQDN="buildmaster",
+                masterFQDN=master_fqdn,
                 volumes=[f"buildbot-worker-{worker_name}:{worker_persist}"],
                 hostconfig={
                     "network_mode": docker_network,

--- a/buildbot-host/buildmaster/worker-default.ini
+++ b/buildbot-host/buildmaster/worker-default.ini
@@ -4,6 +4,8 @@ extra_build_flags=""
 type=latent_docker
 ostype=unix
 password=vagrant
+master_fqdn=172.18.0.1
+docker_url=tcp://172.18.0.1:2375
 
 # Build types
 enable_debian_builds=true
@@ -30,17 +32,48 @@ openvpn3_linux_command_prefix=["/bin/sh", "-c"]
 image=openvpn_community/buildbot-worker-debian-11:v1.0.3
 enable_openvpn3-linux_builds=false
 
+[debian-11-arm64]
+master_fqdn=10.29.32.1
+docker_url=tcp://10.29.32.2:2375
+image=openvpn_community/buildbot-worker-debian-11:v1.0.3
+enable_openvpn3-linux_builds=false
+
 [debian-12]
 image=openvpn_community/buildbot-worker-debian-12:v1.1.0
 
+[debian-12-arm64]
+master_fqdn=10.29.32.1
+docker_url=tcp://10.29.32.2:2375
+image=openvpn_community/buildbot-worker-debian-12:v1.1.0
+
 [debian-unstable]
+image=openvpn_community/buildbot-worker-debian-unstable:v1.1.0
+
+[debian-unstable-arm64]
+master_fqdn=10.29.32.1
+docker_url=tcp://10.29.32.2:2375
 image=openvpn_community/buildbot-worker-debian-unstable:v1.1.0
 
 [arch]
 image=openvpn_community/buildbot-worker-arch:v1.1.0
 enable_debian_builds=false
 
+# Arch Linux does not have arm64 images as of August 2024
+#[arch-arm64]
+#master_fqdn=10.29.32.1
+#docker_url=tcp://10.29.32.2:2375
+#image=openvpn_community/buildbot-worker-arch:v1.1.0
+#enable_debian_builds=false
+
 [alpine]
+image=openvpn_community/buildbot-worker-alpine-3:v1.1.0
+enable_debian_builds=false
+enable_openvpn3_builds=false
+enable_openvpn3-linux_builds=false
+
+[alpine-arm64]
+master_fqdn=10.29.32.1
+docker_url=tcp://10.29.32.2:2375
 image=openvpn_community/buildbot-worker-alpine-3:v1.1.0
 enable_debian_builds=false
 enable_openvpn3_builds=false
@@ -50,13 +83,31 @@ enable_openvpn3-linux_builds=false
 image=openvpn_community/buildbot-worker-fedora-39:v1.1.0
 enable_debian_builds=false
 
+[fedora-39-arm64]
+master_fqdn=10.29.32.1
+docker_url=tcp://10.29.32.2:2375
+image=openvpn_community/buildbot-worker-fedora-39:v1.1.0
+enable_debian_builds=false
+
 [fedora-40]
 image=openvpn_community/buildbot-worker-fedora-40:v1.1.0
 enable_debian_builds=false
 
-#[fedora-rawhide]
-#image=openvpn_community/buildbot-worker-fedora-rawhide:v1.1.0
-#enable_debian_builds=false
+[fedora-40-arm64]
+master_fqdn=10.29.32.1
+docker_url=tcp://10.29.32.2:2375
+image=openvpn_community/buildbot-worker-fedora-40:v1.1.0
+enable_debian_builds=false
+
+[fedora-rawhide]
+image=openvpn_community/buildbot-worker-fedora-rawhide:v1.1.0
+enable_debian_builds=false
+
+[fedora-rawhide-arm64]
+master_fqdn=10.29.32.1
+docker_url=tcp://10.29.32.2:2375
+image=openvpn_community/buildbot-worker-fedora-rawhide:v1.1.0
+enable_debian_builds=false
 
 [opensuse-leap-15]
 image=openvpn_community/buildbot-worker-opensuse-leap-15:v1.0.2
@@ -70,15 +121,28 @@ openvpn_extra_config_opts=--disable-dco
 image=openvpn_community/buildbot-worker-ubuntu-2004:v1.0.3
 enable_openvpn3-linux_builds=false
 
-#[ubuntu-2004-vm-static]
-#type=normal
-#ostype=unix
+[ubuntu-2004-arm64]
+master_fqdn=10.29.32.1
+docker_url=tcp://10.29.32.2:2375
+image=openvpn_community/buildbot-worker-ubuntu-2004:v1.0.3
+enable_openvpn3-linux_builds=false
 
 [ubuntu-2204]
 image=openvpn_community/buildbot-worker-ubuntu-2204:v1.1.0
 enable_code-check_builds=true
 
+[ubuntu-2204-arm64]
+master_fqdn=10.29.32.1
+docker_url=tcp://10.29.32.2:2375
+image=openvpn_community/buildbot-worker-ubuntu-2204:v1.1.0
+enable_code-check_builds=true
+
 [ubuntu-2404]
+image=openvpn_community/buildbot-worker-ubuntu-2404:v1.1.0
+
+[ubuntu-2404-arm64]
+master_fqdn=10.29.32.1
+docker_url=tcp://10.29.32.2:2375
 image=openvpn_community/buildbot-worker-ubuntu-2404:v1.1.0
 
 #[macos-amd64]


### PR DESCRIPTION
This PR adds support for using an arbitrary number of external Docker hosts. The primary target is to be able to run builds on an external ARM64 Docker host. Testing was done with an external Ubuntu 24.04 ARM64 Docker host.

Documentation in README.md and the examples in master-default.ini and worker-default.ini should contain all the information required to spin up a secondary (e.g. ARM64) Docker host and use it in Buildbot.

This PR changes the configuration file format somewhat, so small changes are needed even if a secondary Docker host is not present. The docker section in master.ini should look like this:

```
[docker]
network=buildbot-net
max_builds={ "172.18.0.1": 4 }
```

The key in *max_builds* must refer to a Docker host found from one or more *docker_url* settings in worker.ini (see below). Also Note that the *host* setting is now gone.

In worker.ini you need to define two new parameters:

```
[DEFAULT]
master_fqdn=172.18.0.1
docker_url=tcp://172.18.0.1:2375
```

The *master_fqdn* parameter is the IP (or hostname) of the Buildmaster from the Buildbot Worker's perspective. The *docker_url* should point to the Docker daemon this particular Buildbot Worker lives on.

During testing I found and fixed some unrelated issues. There are separate PRs for those:

* https://github.com/OpenVPN/openvpn-buildbot/pull/59
* https://github.com/OpenVPN/openvpn-buildbot/pull/60

Note that there are unrelated issues that prevent some Buildbot Workers from being used:

* Our current Buildbot Worker version does not seem to work on Fedora Rawhide. It fails due to errors in "pipes" library.
* The version of ASIO in alpine-3 does not work as intended.
* Arch Linux does not have an ARM64 container image available. 