### PR TITLE
t_client: Handle SSL libraries without BF-CBC support

### DIFF
--- a/buildbot-host/buildmaster/worker-default.ini
+++ b/buildbot-host/buildmaster/worker-default.ini
@@ -111,7 +111,7 @@ image=openvpn_community/buildbot-worker-fedora-rawhide:v1.1.0
 enable_debian_builds=false
 
 [opensuse-leap-15]
-image=openvpn_community/buildbot-worker-opensuse-leap-15:v1.0.2
+image=openvpn_community/buildbot-worker-opensuse-leap-15:v1.0.3
 enable_debian_builds=false
 # Kernel headers are not usable on this platform out of the box
 enable_ovpn-dco_builds=false

--- a/buildbot-host/scripts/install-openvpn-build-deps-arch.sh
+++ b/buildbot-host/scripts/install-openvpn-build-deps-arch.sh
@@ -33,7 +33,7 @@ linux-headers \
 lz4 \
 lzo \
 make \
-mbedtls2 \
+mbedtls \
 meson \
 openssh \
 openssl \

--- a/buildbot-host/t_client/t_client.rc
+++ b/buildbot-host/t_client/t_client.rc
@@ -209,6 +209,7 @@ PING6_HOSTS_2="fd00:abcd:194:2::1 fd00:abcd:194:0::1"
 # gert, 20.9.21, add --data-ciphers BF-CBC to force BF-CBC (MTU/frame)
 
 RUN_TITLE_2a="udp4 / p2pm / v6-only / --multihome"
+CHECK_SKIP_2a="${openvpn} --providers legacy default --show-ciphers | grep -q '^BF-CBC  '"
 OPENVPN_CONF_2a="$OPENVPN_BASE_P2MP --dev tun --proto udp4 --remote $REMOTE --port 51194 --route-nopull --route-ipv6 fd00:abcd:194::/48 --multihome --nobind --cipher BF-CBC --data-ciphers BF-CBC --providers legacy default"
 # geht nicht auf FreeBSD
 #if [ `uname -o` = "GNU/Linux" ] ; then


### PR DESCRIPTION
Currently this is mbedTLS v3. Used by opensuse and arch workers now.