### PR TITLE
debian-package.sh: Remove -arm64 suffix from worker name

### DIFF
--- a/buildbot-host/buildmaster/debian-package.sh
+++ b/buildbot-host/buildmaster/debian-package.sh
@@ -14,7 +14,7 @@ while getopts "hw:c:s:" arg; do
       exit 0
       ;;
     w)
-      WORKERNAME=$OPTARG
+      WORKERNAME=${OPTARG%%-arm64}
       ;;
   esac
 done


### PR DESCRIPTION
Crude work-around for now. Might want to come up with something better. But for now this fixes the build problems.