### PR TITLE
Run t_server_null.sh tests with release/2.5 and release/2.6 clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Buildbot master should now be listening on port 8010.
 * Server tests with t_server_null.sh (see OpenVPN Git repository)
 * Unix connectivity tests using t_client.sh (see OpenVPN Git repository)
 * Native Windows builds using MSVC to (cross-)compile for x86, x64 and arm64 plus MSI packaging and signing. Not actively tested.
+* Server tests using t_server_null.sh
+    * Git master client -> Git master servers
+    * Git release/2.6 client -> Git master servers
+    * Git release/2.5 client -> Git master servers
 * Debian/Ubuntu packaging
 
 ## openvpn3

--- a/buildbot-host/buildbot-worker-debian-12-openvpn-legacy/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-debian-12-openvpn-legacy/Dockerfile.base
@@ -1,0 +1,5 @@
+ARG IMAGE=debian:12
+ARG DEPS_SH=install-openvpn-build-deps-ubuntu.sh
+ARG MY_NAME="buildbot-worker-debian-12-openvpn-legacy"
+ARG PIP_INSTALL_OPTS="--break-system-packages"
+ARG MY_VERSION="v1.0.0"

--- a/buildbot-host/buildbot-worker-debian-12-openvpn-legacy/Dockerfile.suffix
+++ b/buildbot-host/buildbot-worker-debian-12-openvpn-legacy/Dockerfile.suffix
@@ -1,0 +1,5 @@
+ARG OPENVPN_LEGACY_SH=install-openvpn-legacy.sh
+COPY scripts/${OPENVPN_LEGACY_SH} /buildbot/
+RUN /buildbot/${OPENVPN_LEGACY_SH}
+
+COPY ${MY_NAME}/t_server_null.rc-legacy /buildbot/t_server_null.rc

--- a/buildbot-host/buildbot-worker-debian-12-openvpn-legacy/env
+++ b/buildbot-host/buildbot-worker-debian-12-openvpn-legacy/env
@@ -1,0 +1,3 @@
+BUILDMASTER=buildmaster
+WORKERNAME=debian-12-openvpn-legacy
+WORKERPASS=vagrant

--- a/buildbot-host/buildbot-worker-debian-12-openvpn-legacy/t_server_null.rc
+++ b/buildbot-host/buildbot-worker-debian-12-openvpn-legacy/t_server_null.rc
@@ -1,0 +1,2 @@
+# This file gets overwritten in Dockerfile.suffix. It's main purpose in life is
+# to enable better reuse of Docker layers.

--- a/buildbot-host/buildbot-worker-debian-12-openvpn-legacy/t_server_null.rc-legacy
+++ b/buildbot-host/buildbot-worker-debian-12-openvpn-legacy/t_server_null.rc-legacy
@@ -1,0 +1,67 @@
+TEST_RUN_LIST="1a 1b 1c 1d 2a 2b 2c 2d 3a 3b 3c 3d"
+
+# OpenVPN 2.5 does not support --explicit-exit-notify option in TCP mode.
+# Otherwise these base options match CLIENT_BASE_OPTS in
+# t_server_null_default.rc.
+CLIENT_BASE_OPTS_25_TCP="--client --dev null --ifconfig-noexec --nobind --remote-cert-tls server --persist-tun --verb 3 --resolv-retry infinite --connect-retry-max 3 --server-poll-timeout 5 --script-security 2 --up ${srcdir}/null_client_up.sh"
+CLIENT_CONF_BASE_25_TCP="${CLIENT_BASE_OPTS_25_TCP} ${CLIENT_CIPHER_OPTS} ${CLIENT_CERT_OPTS}"
+
+TEST_NAME_1a="t_server_null_client.sh-openvpn_26_openssl_udp"
+SHOULD_PASS_1a="${SHOULD_PASS_1}"
+CLIENT_EXEC_1a="/opt/openvpn-2.6-openssl/sbin/openvpn"
+CLIENT_CONF_1a="${CLIENT_CONF_1}"
+
+TEST_NAME_1b="t_server_null_client.sh-openvpn_26_mbedtls_udp"
+SHOULD_PASS_1b="${SHOULD_PASS_1}"
+CLIENT_EXEC_1b="/opt/openvpn-2.6-mbedtls/sbin/openvpn"
+CLIENT_CONF_1b="${CLIENT_CONF_1}"
+
+TEST_NAME_1c="t_server_null_client.sh-openvpn_25_openssl_udp"
+SHOULD_PASS_1c="${SHOULD_PASS_1}"
+CLIENT_EXEC_1c="/opt/openvpn-2.5-openssl/sbin/openvpn"
+CLIENT_CONF_1c="${CLIENT_CONF_1}"
+
+TEST_NAME_1d="t_server_null_client.sh-openvpn_25_mbedtls_udp"
+SHOULD_PASS_1d="${SHOULD_PASS_1}"
+CLIENT_EXEC_1d="/opt/openvpn-2.5-mbedtls/sbin/openvpn"
+CLIENT_CONF_1d="${CLIENT_CONF_1}"
+
+TEST_NAME_2a="t_server_null_client.sh-openvpn_26_openssl_tcp"
+SHOULD_PASS_2a="${SHOULD_PASS_2}"
+CLIENT_EXEC_2a="/opt/openvpn-2.6-openssl/sbin/openvpn"
+CLIENT_CONF_2a="${CLIENT_CONF_2}"
+
+TEST_NAME_2b="t_server_null_client.sh-openvpn_26_mbedtls_tcp"
+SHOULD_PASS_2b="${SHOULD_PASS_2}"
+CLIENT_EXEC_2b="/opt/openvpn-2.6-mbedtls/sbin/openvpn"
+CLIENT_CONF_2b="${CLIENT_CONF_2}"
+
+TEST_NAME_2c="t_server_null_client.sh-openvpn_25_openssl_tcp"
+SHOULD_PASS_2c="${SHOULD_PASS_2}"
+CLIENT_EXEC_2c="/opt/openvpn-2.5-openssl/sbin/openvpn"
+CLIENT_CONF_2c="${CLIENT_CONF_BASE_25_TCP} --remote 127.0.0.1 1195 tcp --proto tcp"
+
+TEST_NAME_2d="t_server_null_client.sh-openvpn_25_mbedtls_tcp"
+SHOULD_PASS_2d="${SHOULD_PASS_2}"
+CLIENT_EXEC_2d="/opt/openvpn-2.5-mbedtls/sbin/openvpn"
+CLIENT_CONF_2d="${CLIENT_CONF_BASE_25_TCP} --remote 127.0.0.1 1195 tcp --proto tcp"
+
+TEST_NAME_3a="t_server_null_client.sh-openvpn_26_openssl_udp_fail"
+SHOULD_PASS_3a="${SHOULD_PASS_3}"
+CLIENT_EXEC_3a="/opt/openvpn-2.6-openssl/sbin/openvpn"
+CLIENT_CONF_3a="${CLIENT_CONF_3}"
+
+TEST_NAME_3b="t_server_null_client.sh-openvpn_26_mbedtls_udp_fail"
+SHOULD_PASS_3b="${SHOULD_PASS_3}"
+CLIENT_EXEC_3b="/opt/openvpn-2.6-mbedtls/sbin/openvpn"
+CLIENT_CONF_3b="${CLIENT_CONF_3}"
+
+TEST_NAME_3c="t_server_null_client.sh-openvpn_25_openssl_udp_fail"
+SHOULD_PASS_3c="${SHOULD_PASS_3}"
+CLIENT_EXEC_3c="/opt/openvpn-2.5-openssl/sbin/openvpn"
+CLIENT_CONF_3c="${CLIENT_CONF_3}"
+
+TEST_NAME_3d="t_server_null_client.sh-openvpn_25_mbedtls_udp_fail"
+SHOULD_PASS_3d="${SHOULD_PASS_3}"
+CLIENT_EXEC_3d="/opt/openvpn-2.5-mbedtls/sbin/openvpn"
+CLIENT_CONF_3d="${CLIENT_CONF_3}"

--- a/buildbot-host/buildmaster/worker-default.ini
+++ b/buildbot-host/buildmaster/worker-default.ini
@@ -47,6 +47,9 @@ master_fqdn=10.29.32.1
 docker_url=tcp://10.29.32.2:2375
 image=openvpn_community/buildbot-worker-debian-12:v1.1.0
 
+[debian-12-openvpn-legacy]
+image=openvpn_community/buildbot-worker-debian-12-openvpn-legacy:v1.0.0
+
 [debian-unstable]
 image=openvpn_community/buildbot-worker-debian-unstable:v1.1.0
 

--- a/buildbot-host/scripts/install-openvpn-legacy.sh
+++ b/buildbot-host/scripts/install-openvpn-legacy.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# Install OpenVPN 2.5 and 2.6
+#
+set -e
+
+install_openvpn() {
+    RELEASE=$1
+    CRYPTO_LIBRARY=$2
+    DEST=/opt/openvpn-$RELEASE-$CRYPTO_LIBRARY
+    echo "Installing OpenVPN $RELEASE compiled against $CRYPTO_LIBRARY to $DEST"
+
+    CWD=$(pwd)
+    cp -a openvpn openvpn-$RELEASE-$CRYPTO_LIBRARY
+    cd openvpn-$RELEASE-$CRYPTO_LIBRARY
+    git checkout -b release/$RELEASE origin/release/$RELEASE
+    autoreconf -vi
+    ./configure --with-crypto-library=$CRYPTO_LIBRARY --prefix=/opt/openvpn-$RELEASE-$CRYPTO_LIBRARY
+    make
+    make install
+    # Remove the build directory to save some disk space
+    rm -rf openvpn-$RELEASE-$CRYPTO_LIBRARY
+    cd $CWD
+}
+
+cd /buildbot
+git clone https://github.com/OpenVPN/openvpn.git
+
+install_openvpn 2.5 mbedtls
+install_openvpn 2.5 openssl
+install_openvpn 2.6 mbedtls
+install_openvpn 2.6 openssl
+


### PR DESCRIPTION
This has been implemented as a special buildbot worker coupled with a customized t_server_null.rc file. That special buildbot worker container image should be rebuilt periodically to ensure we're not using outdated client code.