### PR TITLE
jenkins/windows-server: Drop Windows Server 2019 variants

### DIFF
--- a/jenkins/windows-server/jenkins-agent.pkr.hcl
+++ b/jenkins/windows-server/jenkins-agent.pkr.hcl
@@ -1,8 +1,4 @@
 build {
-  source "amazon-ebs.windows-server-2019" {
-    name     = "jenkins-agent-windows-server-2019"
-    ami_name = "jenkins-agent-windows-server-2019-5-${local.timestamp}"
-  }
   source "amazon-ebs.windows-server-2022" {
     name     = "jenkins-agent-windows-server-2022"
     ami_name = "jenkins-agent-windows-server-2022-3-${local.timestamp}"
@@ -17,7 +13,6 @@ build {
     destination = "C:/config"
   }
   provisioner "powershell" {
-    only   = ["amazon-ebs.jenkins-agent-windows-server-2022"]
     inline = ["& 'C:/Program Files/Amazon/EC2Launch/EC2Launch.exe' status --block"]
   }
   provisioner "powershell" {
@@ -58,12 +53,6 @@ build {
   # Required for some installers
   provisioner "windows-restart" {}
   provisioner "powershell" {
-    only = ["amazon-ebs.jenkins-agent-windows-server-2019"]
-    # make sure to run user data scripts on first boot from AMI
-    inline = ["C:/ProgramData/Amazon/EC2-Windows/Launch/Scripts/InitializeInstance.ps1 -Schedule"]
-  }
-  provisioner "powershell" {
-    only = ["amazon-ebs.jenkins-agent-windows-server-2022"]
     # make sure to run user data scripts on first boot from AMI
     inline = ["& 'C:/Program Files/Amazon/EC2Launch/EC2Launch.exe' reset --clean"]
   }

--- a/jenkins/windows-server/msibuild.pkr.hcl
+++ b/jenkins/windows-server/msibuild.pkr.hcl
@@ -1,8 +1,4 @@
 build {
-  source "amazon-ebs.windows-server-2019" {
-    name     = "msibuild-windows-server-2019-2.5"
-    ami_name = "msibuild-windows-server-2019-2.5-5"
-  }
   source "amazon-ebs.windows-server-2022" {
     name     = "msibuild-windows-server-2022-2.6"
     ami_name = "msibuild-windows-server-2022-2.6-6"
@@ -43,19 +39,9 @@ build {
     inline = ["C:/Windows/Temp/scripts/pwsh.ps1"]
   }
   provisioner "powershell" {
-    only   = ["amazon-ebs.msibuild-windows-server-2019-2.5"]
-    inline = ["C:/Windows/Temp/scripts/vsbuildtools.ps1 -version 2019"]
-  }
-  provisioner "powershell" {
-    only   = ["amazon-ebs.msibuild-windows-server-2022-2.6"]
     inline = ["C:/Windows/Temp/scripts/vsbuildtools.ps1 -version 2022"]
   }
   provisioner "powershell" {
-    only   = ["amazon-ebs.msibuild-windows-server-2019-2.5"]
-    inline = ["C:/Windows/Temp/scripts/build-deps.ps1 -configfiles C:\\config -workdir C:\\buildbot\\msbuild -openvpn_ref release/2.5 -openvpn_build_ref release/2.5 -openvpn_gui master -openssl openssl -debug"]
-  }
-  provisioner "powershell" {
-    only   = ["amazon-ebs.msibuild-windows-server-2022-2.6"]
     inline = ["C:/Windows/Temp/scripts/build-deps-unified.ps1 -configfiles C:\\config -workdir C:\\buildbot\\msbuild -openvpn_build_ref release/2.6 -debug"]
   }
   provisioner "powershell" {

--- a/jenkins/windows-server/msitest.pkr.hcl
+++ b/jenkins/windows-server/msitest.pkr.hcl
@@ -1,7 +1,7 @@
 build {
   source "amazon-ebs.windows-server-2022" {
     name     = "msitest-windows-server-2022"
-    ami_name = "msitest-agent-windows-server-2022-2"
+    ami_name = "msitest-agent-windows-server-2022-3"
   }
 
   provisioner "file" {
@@ -30,7 +30,6 @@ build {
   # Required for some installers
   #provisioner "windows-restart" {}
   provisioner "powershell" {
-    only = ["amazon-ebs.msitest-windows-server-2022"]
     # make sure to run user data scripts on first boot from AMI
     inline = ["& 'C:/Program Files/Amazon/EC2Launch/EC2Launch.exe' reset --clean"]
   }

--- a/jenkins/windows-server/shared.pkr.hcl
+++ b/jenkins/windows-server/shared.pkr.hcl
@@ -41,50 +41,6 @@ variable "run_tags" {
   }
 }
 
-source "amazon-ebs" "windows-server-2019" {
-  communicator         = "winrm"
-  force_deregister     = true
-  instance_type        = "c6a.xlarge"
-  iam_instance_profile = var.windows_server_instance_profile
-  region               = var.windows_server_ec2_region
-  subnet_id            = var.windows_server_ec2_subnet
-
-  launch_block_device_mappings {
-    device_name           = "/dev/sda1"
-    volume_size           = 80
-    volume_type           = "gp3"
-    delete_on_termination = true
-  }
-
-  source_ami_filter {
-    filters = {
-      name                = "Windows_Server-2019-English-Full-Base-*"
-      root-device-type    = "ebs"
-      virtualization-type = "hvm"
-    }
-    most_recent = true
-    owners      = ["801119661308"]
-  }
-  user_data      = templatefile("${path.root}/../../pkrtpl/bootstrap_win.pkrtpl.hcl", { winrm_password = var.windows_server_winrm_password })
-  winrm_password = var.windows_server_winrm_password
-  winrm_username = "Administrator"
-
-  tags = {
-    SourceAMI     = "{{ .SourceAMI }}"
-    SourceAMIName = "{{ .SourceAMIName }}"
-    Login         = local.user_name
-  }
-
-  dynamic "run_tag" {
-    for_each = var.run_tags
-
-    content {
-      key   = run_tag.key
-      value = run_tag.value
-    }
-  }
-}
-
 source "amazon-ebs" "windows-server-2022" {
   communicator         = "winrm"
   force_deregister     = true


### PR DESCRIPTION
We haven't used them in quite some time, so let's not continue to waste time building them.

Does not touch buildbot-host/buildbot-worker-windows-server-2019. While that is even more unused (and probably broken), it might still be useful as a starting point if we want to start running our own Windows build agents again.