### PR TITLE
Add MingW and Unix CMake builds

### DIFF
--- a/buildbot-host/buildbot-worker-ubuntu-2404/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-ubuntu-2404/Dockerfile.base
@@ -2,4 +2,5 @@ ARG IMAGE=ubuntu:24.04
 ARG DEPS_SH=install-openvpn-build-deps-ubuntu.sh
 ARG MY_NAME="buildbot-worker-ubuntu-2404"
 ARG PIP_INSTALL_OPTS="--break-system-packages"
-ARG MY_VERSION="v1.1.0"
+ARG INSTALL_MINGW=true
+ARG MY_VERSION="v1.2.0"

--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -439,7 +439,9 @@ def can_sign(buildstep):
 # OpenVPN 2 build steps
 for steps_file in [
     "common_unix_steps.cfg",
+    "cmake_unix_steps.cfg",
     "common_windows_steps.cfg",
+    "common_mingw_steps.cfg",
     "debian_packaging_steps.cfg",
     "device_setup_steps.cfg",
     "tserver_null_pre_steps.cfg",
@@ -622,6 +624,38 @@ factories.update(
 )
 del factory
 
+# OpenVPN 2 cmake build
+factory = util.BuildFactory()
+factory = openvpnAddCmakeUnixStepsToBuildFactory(factory, ccache)
+factory_name = "cmake"
+factories.update(
+    {
+        factory_name: {
+            "factory": factory,
+            "os": "unix",
+            "types": ["openvpn", "cmake"],
+            "schedulers": ["openvpn_main", "openvpn_release"],
+        }
+    }
+)
+del factory
+
+# OpenVPN 2 Windows mingw build
+factory = util.BuildFactory()
+factory = openvpnAddCommonMingwStepsToBuildFactory(factory, ccache)
+factory_name = "mingw"
+factories.update(
+    {
+        factory_name: {
+            "factory": factory,
+            "os": "unix",
+            "types": ["openvpn", "mingw"],
+            "schedulers": ["openvpn_main", "openvpn_release"],
+        }
+    }
+)
+del factory
+
 # openvpn3 smoketest
 factory = util.BuildFactory()
 factory = openvpn3AddCommonLinuxStepsToBuildFactory(factory)
@@ -739,7 +773,9 @@ for factory_name, factory in factories.items():
             "openssl",
             "mbedtls",
             "debian",
+            "mingw",
             "msbuild",
+            "cmake",
             "compile",
             "tclient",
             "ovpn-dco",

--- a/buildbot-host/buildmaster/openvpn/cmake_unix_steps.cfg
+++ b/buildbot-host/buildmaster/openvpn/cmake_unix_steps.cfg
@@ -1,0 +1,71 @@
+# -*- python -*-
+# ex: set filetype=python:
+def openvpnAddCmakeUnixStepsToBuildFactory(factory, shell_env=None):
+    if shell_env is None:
+        shell_env = {}
+
+    factory.addStep(
+        steps.Git(
+            repourl=util.Interpolate("%(prop:repository)s"),
+            mode="incremental",
+            name="clone",
+            description="cloning",
+            descriptionDone="clone",
+        )
+    )
+
+    factory.addStep(
+        steps.ShellCommand(
+            command="ccache -z",
+            name="ccache reset",
+            decodeRC={0: SUCCESS, 127: WARNINGS},
+            description="resetting stats",
+            descriptionDone="resetting stats",
+            env=shell_env,
+        )
+    )
+
+    factory.addStep(
+        steps.ShellCommand(
+            command=["cmake", "--preset", "unix-native", "-DUNSUPPORTED_BUILDS=ON"],
+            name="configure",
+            description="configuring",
+            descriptionDone="configure",
+            env=shell_env,
+            haltOnFailure=True,
+        )
+    )
+
+    factory.addStep(
+        steps.ShellCommand(
+            command=["cmake", "--build", "--preset", "unix-native", "--parallel=1"],
+            name="build",
+            description="building",
+            descriptionDone="build",
+            env=shell_env,
+            haltOnFailure=True,
+        )
+    )
+
+    factory.addStep(
+        steps.ShellCommand(
+            command=["ctest", "--preset", "unix-native", "--output-on-failure"],
+            name="test",
+            description="testing",
+            descriptionDone="test",
+            env=shell_env,
+        )
+    )
+
+    factory.addStep(
+        steps.ShellCommand(
+            command="ccache -s",
+            decodeRC={0: SUCCESS, 127: WARNINGS},
+            name="ccache show",
+            description="showing stats",
+            descriptionDone="showing stats",
+            env=shell_env,
+        )
+    )
+
+    return factory

--- a/buildbot-host/buildmaster/openvpn/common_mingw_steps.cfg
+++ b/buildbot-host/buildmaster/openvpn/common_mingw_steps.cfg
@@ -1,0 +1,59 @@
+# -*- python -*-
+# ex: set filetype=python:
+def openvpnAddCommonMingwStepsToBuildFactory(factory, shell_env=None):
+    if shell_env is None:
+        shell_env = {}
+
+    factory.addStep(
+        steps.Git(
+            repourl=util.Interpolate("%(prop:repository)s"),
+            mode="incremental",
+            name="clone",
+            description="cloning",
+            descriptionDone="clone",
+        )
+    )
+
+    factory.addStep(
+        steps.ShellCommand(
+            command="ccache -z",
+            name="ccache reset",
+            decodeRC={0: SUCCESS, 127: WARNINGS},
+            description="resetting stats",
+            descriptionDone="resetting stats",
+            env=shell_env,
+        )
+    )
+
+    factory.addStep(
+        steps.ShellCommand(
+            command="mkdir -p $VCPKG_DEFAULT_BINARY_CACHE",
+            name="create vcpkg cache directory",
+            description="preparing",
+            descriptionDone="prepare",
+        )
+    )
+
+    factory.addStep(
+        steps.ShellCommand(
+            command=["cmake", "--preset", "mingw-x64"],
+            name="configure",
+            description="configuring",
+            descriptionDone="configure",
+            env=shell_env,
+            haltOnFailure=True,
+        )
+    )
+
+    factory.addStep(
+        steps.ShellCommand(
+            command=["cmake", "--build", "--preset", "mingw-x64", "--parallel=1"],
+            name="build",
+            description="building",
+            descriptionDone="build",
+            env=shell_env,
+            haltOnFailure=True,
+        )
+    )
+
+    return factory

--- a/buildbot-host/buildmaster/worker-default.ini
+++ b/buildbot-host/buildmaster/worker-default.ini
@@ -10,6 +10,8 @@ docker_url=tcp://172.18.0.1:2375
 # Build types
 enable_debian_builds=true
 enable_msbuild_builds=false
+enable_mingw_builds=false
+enable_cmake_builds=false
 enable_compile_builds=true
 enable_tclient_builds=true
 enable_openssl_builds=true
@@ -147,7 +149,10 @@ image=openvpn_community/buildbot-worker-ubuntu-2204:v1.1.0
 enable_code-check_builds=true
 
 [ubuntu-2404]
-image=openvpn_community/buildbot-worker-ubuntu-2404:v1.1.0
+image=openvpn_community/buildbot-worker-ubuntu-2404:v1.2.0
+enable_mingw_builds=true
+enable_cmake_builds=true
+openvpn_extra_config_opts=--enable-werror
 
 [ubuntu-2404-arm64]
 master_fqdn=10.29.32.1

--- a/buildbot-host/scripts/install-openvpn-build-deps-ubuntu.sh
+++ b/buildbot-host/scripts/install-openvpn-build-deps-ubuntu.sh
@@ -77,6 +77,28 @@ python3-wheel \
 uncrustify \
 uuid-dev
 
+if [ "${INSTALL_MINGW:-false}" = "true" ]; then
+  # MingW + vcpkg
+  $APT_INSTALL \
+  man2html-base \
+  mingw-w64 \
+  ninja-build \
+  unzip \
+  zip
+
+  cd /opt
+  git clone https://github.com/microsoft/vcpkg
+  cd vcpkg
+  ./bootstrap-vcpkg.sh
+
+  $APT_INSTALL wget software-properties-common
+  wget -q "https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb"
+  dpkg -i packages-microsoft-prod.deb
+  rm -f packages-microsoft-prod.deb
+  apt-get update
+  $APT_INSTALL powershell
+fi
+
 # Only for some distros
 $APT_INSTALL systemd-dev || true
 


### PR DESCRIPTION
Both are disabled by default. MingW because we probably only want to do them on one specific worker. CMake because we will need to verify individual workers before enabling the builds. Since the Unix builds are not officially "supported" we might not care to limit them to a smaller number of platforms.