### PR TITLE
buildmaster: Fix mail notifiers

### DIFF
--- a/buildbot-host/buildmaster/Dockerfile
+++ b/buildbot-host/buildmaster/Dockerfile
@@ -1,5 +1,5 @@
 ARG MY_NAME="buildmaster"
-ARG MY_VERSION="v2.7.0"
+ARG MY_VERSION="v2.7.1"
 ARG IMAGE=buildbot/buildbot-master:v3.11.9
 
 FROM $IMAGE

--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -406,6 +406,7 @@ for docker_host, maxcount in max_builds.items():
 # convenience feature to reduce the number of keys required for t_client tests.
 docker_tclient_lock = util.MasterLock("docker", maxCount=1)
 
+
 def getBuilderNameSuffix(combo):
     """Generate builder name suffix from configure options"""
     if not combo:
@@ -844,6 +845,48 @@ for factory_name, factory in factories.items():
 # We need to create schedulers after the builders, because otherwise the build
 # name lists are not available yet.
 c["schedulers"] = []
+c["services"] = []
+
+mail_template = """\
+Build status: {{ summary }}
+Worker used: {{ workername }}
+Build URL: {{ build_url }}
+
+Exit codes for the build steps:
+{% for step in build['steps'] %}
+{{ step['name'] }}: {{ step['results'] }}
+{% endfor %}
+
+-- Buildbot
+"""
+
+
+def create_mails(name, mail_addresses, schedulers):
+    """Send mails for builds in schedulers to specific addresses"""
+    generator = reporters.BuildStatusGenerator(
+        mode=("failing",),
+        schedulers=schedulers,
+        add_logs=True,
+        message_formatter=reporters.MessageFormatter(
+            template_type="plain",
+            template=mail_template,
+            want_steps=True,
+            want_logs=True,
+            want_logs_content=True,
+        ),
+    )
+
+    mn = reporters.MailNotifier(
+        name=f"mn-{name}",
+        fromaddr=fromaddr,
+        sendToInterestedUsers=False,
+        extraRecipients=mail_addresses,
+        relayhost=relayhost,
+        generators=[generator],
+    )
+
+    c["services"].append(mn)
+
 
 # Only build if any of the files in the Change match this regular expression
 openvpn_file_patterns = [
@@ -877,14 +920,14 @@ for branch_type, branch_name in openvpn_branches.items():
         ),
         treeStableTimer=openvpn_tree_stable_timer,
         builderNames=builder_names["openvpn-smoketest"],
-        properties={ 'owner': openvpn_owner },
+        properties={"owner": openvpn_owner},
     )
 
     openvpn_full_scheduler = schedulers.Dependent(
         name=f"openvpn-full-{branch_type}",
         upstream=openvpn_smoketest_scheduler,
         builderNames=builder_names[f"openvpn_{branch_type}"],
-        properties={ 'owner': openvpn_owner },
+        properties={"owner": openvpn_owner},
     )
 
     openvpn_gerrit_smoketest_scheduler = schedulers.SingleBranchScheduler(
@@ -904,38 +947,53 @@ for branch_type, branch_name in openvpn_branches.items():
         priority=1,
         treeStableTimer=openvpn_tree_stable_timer,
         builderNames=builder_names["openvpn-smoketest"],
-        properties={ 'owner': openvpn_owner },
+        properties={"owner": openvpn_owner},
     )
 
     openvpn_gerrit_full_scheduler = schedulers.Dependent(
         name=f"openvpn-gerrit-full-{branch_type}",
         upstream=openvpn_gerrit_smoketest_scheduler,
         builderNames=builder_names[f"openvpn_{branch_type}"],
-        properties={ 'owner': openvpn_owner },
+        properties={"owner": openvpn_owner},
     )
 
     c["schedulers"].append(openvpn_smoketest_scheduler)
     c["schedulers"].append(openvpn_full_scheduler)
     c["schedulers"].append(openvpn_gerrit_smoketest_scheduler)
     c["schedulers"].append(openvpn_gerrit_full_scheduler)
+    create_mails(
+        f"openvpn-{branch_type}",
+        extra_recipients + [openvpn_owner],
+        [
+            openvpn_smoketest_scheduler.name,
+            openvpn_full_scheduler.name,
+            openvpn_gerrit_smoketest_scheduler.name,
+            openvpn_gerrit_full_scheduler.name,
+        ],
+    )
 
 openvpn3_smoketest_scheduler = schedulers.SingleBranchScheduler(
     name="openvpn3-smoketest",
     change_filter=util.ChangeFilter(branch=openvpn3_branch, project="openvpn3"),
     treeStableTimer=openvpn3_tree_stable_timer,
     builderNames=builder_names["openvpn3-smoketest"],
-    properties={ 'owner': openvpn3_owner },
+    properties={"owner": openvpn3_owner},
 )
 
 openvpn3_default_scheduler = schedulers.Dependent(
     name="openvpn3-default",
     upstream=openvpn3_smoketest_scheduler,
     builderNames=builder_names["openvpn3"],
-    properties={ 'owner': openvpn3_owner },
+    properties={"owner": openvpn3_owner},
 )
 
 c["schedulers"].append(openvpn3_smoketest_scheduler)
 c["schedulers"].append(openvpn3_default_scheduler)
+create_mails(
+    "openvpn3",
+    extra_recipients + [openvpn3_owner],
+    [openvpn3_smoketest_scheduler.name, openvpn3_default_scheduler.name],
+)
 
 openvpn3_linux_smoketest_scheduler = schedulers.SingleBranchScheduler(
     name="openvpn3-linux-smoketest",
@@ -945,36 +1003,46 @@ openvpn3_linux_smoketest_scheduler = schedulers.SingleBranchScheduler(
     ),
     treeStableTimer=openvpn3_linux_tree_stable_timer,
     builderNames=builder_names["openvpn3-linux-smoketest"],
-    properties={ 'owner': openvpn3_linux_owner },
+    properties={"owner": openvpn3_linux_owner},
 )
 
 openvpn3_linux_default_scheduler = schedulers.Dependent(
     name="openvpn3-linux-default",
     upstream=openvpn3_linux_smoketest_scheduler,
     builderNames=builder_names["openvpn3-linux"],
-    properties={ 'owner': openvpn3_linux_owner },
+    properties={"owner": openvpn3_linux_owner},
 )
 
 c["schedulers"].append(openvpn3_linux_smoketest_scheduler)
 c["schedulers"].append(openvpn3_linux_default_scheduler)
+create_mails(
+    "openvpn3_linux",
+    extra_recipients + [openvpn3_linux_owner],
+    [openvpn3_linux_smoketest_scheduler.name, openvpn3_linux_default_scheduler.name],
+)
 
 ovpn_dco_smoketest_scheduler = schedulers.SingleBranchScheduler(
     name="ovpn-dco-smoketest",
     change_filter=util.ChangeFilter(branch=ovpn_dco_branch, project="ovpn-dco"),
     treeStableTimer=ovpn_dco_tree_stable_timer,
     builderNames=builder_names["ovpn-dco-smoketest"],
-    properties={ 'owner': ovpn_dco_owner },
+    properties={"owner": ovpn_dco_owner},
 )
 
 ovpn_dco_default_scheduler = schedulers.Dependent(
     name="ovpn-dco-default",
     upstream=ovpn_dco_smoketest_scheduler,
     builderNames=builder_names["ovpn-dco"],
-    properties={ 'owner': ovpn_dco_owner },
+    properties={"owner": ovpn_dco_owner},
 )
 
 c["schedulers"].append(ovpn_dco_smoketest_scheduler)
 c["schedulers"].append(ovpn_dco_default_scheduler)
+create_mails(
+    "ovpn_dco",
+    extra_recipients + [ovpn_dco_owner],
+    [ovpn_dco_smoketest_scheduler.name, ovpn_dco_default_scheduler.name],
+)
 
 c["schedulers"].append(
     schedulers.ForceScheduler(
@@ -1059,42 +1127,15 @@ c["schedulers"].append(
     )
 )
 
-c["services"] = []
-
-template = """\
-Build status: {{ summary }}
-Worker used: {{ workername }}
-Build URL: {{ build_url }}
-
-Exit codes for the build steps:
-{% for step in build['steps'] %}
-{{ step['name'] }}: {{ step['results'] }}
-{% endfor %}
-
--- Buildbot
-"""
-
-generator = reporters.BuildStatusGenerator(
-    mode=("failing",),
-    add_logs=True,
-    message_formatter=reporters.MessageFormatter(
-        template_type="plain",
-        template=template,
-        want_steps=True,
-        want_logs=True,
-        want_logs_content=True,
-    ),
-)
-
-mn = reporters.MailNotifier(
+missing_mn = reporters.MailNotifier(
     fromaddr=fromaddr,
     sendToInterestedUsers=False,
     extraRecipients=extra_recipients,
     relayhost=relayhost,
-    generators=[generator, reporters.WorkerMissingGenerator()],
+    generators=[reporters.WorkerMissingGenerator()],
 )
 
-c["services"].append(mn)
+c["services"].append(missing_mn)
 
 c["services"].append(
     GerritChecks(


### PR DESCRIPTION
Having the mail notifications done by owners did
not work as we wanted it to since it required us
to enable notifying involved persons. Which was
just a good way to spam people that didn't expect
it. We want the mails to *only* go to the mailing
lists (and some admins).

So instead now we create separate mail notifiers
for each project and use extraRecipients to send
the mails.