### PR TITLE
Add ovpnlwip support

### DIFF
--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -503,6 +503,8 @@ ccache = {
     "CCACHE_MAXSIZE": "1Gi",
 }
 
+lwip_env = { "LWIPOVPN_PATH": "/buildbot/lwipovpnbuild/lwipovpn" }
+
 factories = {}
 
 # OpenVPN 2 Uncrustify code check
@@ -564,6 +566,7 @@ if openvpn_run_tclient_tests or openvpn_run_tserver_null_tests:
     for combo in build_and_test_config_opt_combos:
         make_check_env = {}
         make_check_env.update(ccache)
+        make_check_env.update(lwip_env)
         if openvpn_run_tclient_tests: make_check_env.update({ "TCLIENT_SKIP_RC": "1" })
 
         factory = util.BuildFactory()

--- a/buildbot-host/buildmaster/worker-default.ini
+++ b/buildbot-host/buildmaster/worker-default.ini
@@ -157,7 +157,7 @@ openvpn_extra_config_opts=--enable-werror
 [ubuntu-2404-arm64]
 master_fqdn=10.29.32.1
 docker_url=tcp://10.29.32.2:2375
-image=openvpn_community/buildbot-worker-ubuntu-2404:v1.1.0
+image=openvpn_community/buildbot-worker-ubuntu-2404:v1.2.0
 
 #[macos-amd64]
 #type=normal

--- a/buildbot-host/scripts/install-lwipovpn.sh
+++ b/buildbot-host/scripts/install-lwipovpn.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# Build and install lwipovpn:
+#
+# https://github.com/OpenVPN/lwipovpn
+#
+set -ex
+
+git clone --recursive https://github.com/openvpn/lwipovpn
+cmake -B lwipovpnbuild -S lwipovpn
+cmake --build lwipovpnbuild

--- a/buildbot-host/scripts/install-openvpn-build-deps-ubuntu.sh
+++ b/buildbot-host/scripts/install-openvpn-build-deps-ubuntu.sh
@@ -77,7 +77,7 @@ python3-wheel \
 uncrustify \
 uuid-dev
 
-if [ "${INSTALL_MINGW:-false}" = "true" ]; then
+if [ "${INSTALL_MINGW:-false}" = "true" ] && lscpu|grep -E '^Architecture:[[:space:]]*x86_64$'; then
   # MingW + vcpkg
   $APT_INSTALL \
   man2html-base \

--- a/buildbot-host/snippets/Dockerfile.common
+++ b/buildbot-host/snippets/Dockerfile.common
@@ -15,10 +15,14 @@ RUN set -ex; \
 # Install buildbot
 ARG MY_NAME
 ARG PIP_INSTALL_OPTS
-COPY scripts/install-buildbot.sh t_client/*.crt t_client/*.rc t_client/*.txt ${MY_NAME}/t_client.* ${MY_NAME}/t_server_null.rc /buildbot/
+COPY scripts/install-lwipovpn.sh scripts/install-buildbot.sh t_client/*.crt t_client/*.rc t_client/*.txt ${MY_NAME}/t_client.* ${MY_NAME}/t_server_null.rc /buildbot/
 RUN set -ex; \
     /buildbot/install-buildbot.sh; \
     rm -f /buildbot/install-buildbot.sh
+
+RUN set -ex; \
+    /buildbot/install-lwipovpn.sh; \
+    rm -f /buildbot/install-lwipovpn.sh
 
 COPY buildbot.tac /buildbot/
 RUN mkdir -p /home/buildbot


### PR DESCRIPTION
This change will be a no-operation until lwipovpn test support is merged (https://gerrit.openvpn.net/c/openvpn/+/811).

I've tested these changes on my private Buildbot and all the lwipovpn tests (amd64 and arm64) passed. I encountered a couple of unrelated issues which I'll report separately.