### PR TITLE
Add clang builds

### DIFF
--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -659,6 +659,35 @@ factories.update(
 )
 del factory
 
+# OpenVPN 2 clang + asan test
+clang_env = { "CFLAGS": "-fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer -O2", "CC": "clang" }
+clang_env.update(ccache)
+clang_env.update(lwip_env)
+
+factory = util.BuildFactory()
+factory = openvpnAddCommonUnixStepsToBuildFactory(factory, "", clang_env)
+factory = openvpnAddUnixCompileStepsToBuildFactory(factory, "", clang_env)
+
+if openvpn_run_tserver_null_tests: factory = openvpnAddTServerNullPreStepsToBuildFactory(factory, "", clang_env)
+if openvpn_run_tclient_tests:      factory = openvpnAddTClientPreStepsToBuildFactory(factory, "", clang_env)
+
+factory = openvpnAddCheckStepsToBuildFactory(factory, "", clang_env)
+
+if openvpn_run_tclient_tests:      factory = openvpnAddTClientPostStepsToBuildFactory(factory, "", clang_env)
+
+factory_name = "clang"
+factories.update(
+    {
+        factory_name: {
+            "factory": factory,
+            "os": "unix",
+            "types": ["openvpn", "clang"],
+            "schedulers": ["openvpn_main", "openvpn_release"],
+        }
+    }
+)
+del factory
+
 # openvpn3 smoketest
 factory = util.BuildFactory()
 factory = openvpn3AddCommonLinuxStepsToBuildFactory(factory)
@@ -779,6 +808,7 @@ for factory_name, factory in factories.items():
             "mingw",
             "msbuild",
             "cmake",
+            "clang",
             "compile",
             "tclient",
             "ovpn-dco",

--- a/buildbot-host/buildmaster/worker-default.ini
+++ b/buildbot-host/buildmaster/worker-default.ini
@@ -11,6 +11,7 @@ docker_url=tcp://172.18.0.1:2375
 enable_debian_builds=true
 enable_msbuild_builds=false
 enable_mingw_builds=false
+enable_clang_builds=false
 enable_cmake_builds=false
 enable_compile_builds=true
 enable_tclient_builds=true
@@ -152,6 +153,7 @@ enable_code-check_builds=true
 image=openvpn_community/buildbot-worker-ubuntu-2404:v1.2.0
 enable_mingw_builds=true
 enable_cmake_builds=true
+enable_clang_builds=true
 openvpn_extra_config_opts=--enable-werror
 
 [ubuntu-2404-arm64]

--- a/buildbot-host/scripts/install-openvpn-build-deps-ubuntu.sh
+++ b/buildbot-host/scripts/install-openvpn-build-deps-ubuntu.sh
@@ -17,6 +17,7 @@ autoconf-archive \
 automake \
 build-essential \
 ccache \
+clang \
 cmake \
 curl \
 debhelper \
@@ -101,6 +102,9 @@ fi
 
 # Only for some distros
 $APT_INSTALL systemd-dev || true
+
+# Only needed on Ubuntu 24.04 for clang builds and may freely fail elsewhere
+$APT_INSTALL libclang-rt-18-dev || true
 
 # policykit-1 is not available in more recent operating systems
 $APT_INSTALL policykit-1 || $APT_INSTALL polkitd pkexec


### PR DESCRIPTION
This PR adds clang + asan tests into buildbot. It essentially replicates what we have in GitHub Actions already ([link](https://github.com/OpenVPN/openvpn/blob/master/.github/workflows/build.yaml#L202)).

The build steps are the same as for normal "compile and test" builds but use different environment variables. As we don't have any builder-specific environment variable support this has been implemented as new build type.