### PR TITLE
Packer: Add pipenv to Windows AMIs

### DIFF
--- a/scripts/pip.ps1
+++ b/scripts/pip.ps1
@@ -1,3 +1,4 @@
-Write-Host "Setting up pip"
+Write-Host "Setting up pip/pipenv"
 & python.exe -m ensurepip
 & python.exe -m pip install --upgrade pip
+& python.exe -m pip install pipenv

--- a/scripts/python.ps1
+++ b/scripts/python.ps1
@@ -1,2 +1,4 @@
 Write-Host "Installing python"
 & choco.exe install -y python
+# some of our python scripts do not work with 3.13+, yet
+& choco.exe install -y python312


### PR DESCRIPTION
To allow us to run Python scripts for interacting
with the build infrastructure.

Need Python 3.12 since the Artifactory python
module isn't working with 3.13, yet.