### PR TITLE
Add persistent /build directory for docker workers

### DIFF
--- a/buildbot-host/buildmaster/debian-package.sh
+++ b/buildbot-host/buildmaster/debian-package.sh
@@ -27,6 +27,7 @@ if [ "$WORKERNAME" = "" ] || [ "$TBV" = "" ] || [ "$SV" = "" ]; then
   exit 1
 fi
 
+rm -fr openvpn-$TBV openvpn-$SV
 tar -xf openvpn-$TBV.tar.gz
 mv openvpn-$TBV.tar.gz openvpn_$SV.orig.tar.gz
 mv openvpn-$TBV openvpn-$SV

--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -305,7 +305,10 @@ for worker_name in worker_names:
                 followStartupLogs=True,
                 image=image,
                 masterFQDN=master_fqdn,
-                volumes=[f"buildbot-worker-{worker_name}:{worker_persist}"],
+                volumes=[
+                    f"buildbot-worker-{worker_name}:{worker_persist}",
+                    f"buildbot-worker-{worker_name}-build:/build",
+                ],
                 hostconfig={
                     "network_mode": docker_network,
                     "sysctls": {"net.ipv6.conf.all.disable_ipv6": 0},

--- a/buildbot-host/snippets/Dockerfile.common
+++ b/buildbot-host/snippets/Dockerfile.common
@@ -3,6 +3,7 @@ LABEL maintainer="OpenVPN Community Project"
 USER root
 WORKDIR /buildbot
 
+ENV BUILDBOT_BASEDIR=/build
 ENV ANDROID_HOME=/opt/android
 
 # Install build dependencies for OpenVPN


### PR DESCRIPTION
This should deliver some speedup to builds, especially fast ones (i.e. not t_client ones) for which a
considerably amount of time is spent in steps like git clone.