### PR TITLE
Allow canceling old builds when new commits have arrived

### DIFF
--- a/buildbot-host/buildmaster/master-default.ini
+++ b/buildbot-host/buildmaster/master-default.ini
@@ -3,9 +3,9 @@ owner=root@localhost
 
 [master]
 master_fqdn=buildmaster
-
 buildbot_url=http://192.168.59.114:8010/
 title_url=https://buildmaster.vagrant.local
+cancel_old_builds=false
 
 [email]
 notify_on_missing=["root@localhost"]

--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -24,9 +24,9 @@ from buildbot.reporters.base import ReporterBase
 from buildbot.reporters.generators.build import BuildStartEndStatusGenerator
 from buildbot.reporters.message import MessageFormatterRenderable
 from buildbot.util import httpclientservice
+from buildbot.util.ssfilter import SourceStampFilter
 
 log = Logger()
-
 
 class GerritChecks(ReporterBase):
     name = "GerritChecks"
@@ -200,6 +200,7 @@ master_fqdn = master_config.get("master", "master_fqdn")
 buildbot_url = master_config.get("master", "buildbot_url")
 title_url = master_config.get("master", "title_url")
 docker_network = master_config.get("docker", "network")
+cancel_old_builds = master_config.getboolean("master", "cancel_old_builds")
 
 # Global email settings
 notify_on_missing = json.loads(master_config.get("email", "notify_on_missing"))
@@ -1232,6 +1233,17 @@ c["services"].append(
         baseURL=gerrit_repo_url, auth=("buildbot", gerrit_user_password), verbose=True
     )
 )
+
+# If enabled, cancel previous builds if a new commit is pushed to a non-master
+# branch. This is very useful on development buildbot systems which may start
+# building obsolete commits on startup.
+if cancel_old_builds:
+    obc = util.OldBuildCanceller(
+        "build_canceller",
+        filters=[(builder_names["openvpn_main"], SourceStampFilter(branch_not_eq="master"))]
+    )
+
+    c["services"].append(obc)
 
 c["title"] = "OpenVPN buildbot"
 c["titleURL"] = title_url


### PR DESCRIPTION
This is meant for development buildbot systems that are not always up. On those systems, when buildmaster is launched, it often starts running builds for some obsolete and completely unrelevant commit, which may take a long, long time to finish. With cancel_old_builds set to true in master.ini a new commit to a non-master branch will cancel all previous builds.