### PR TITLE
buildmaster: Automatically split defined workers to separate tclient …

### DIFF
--- a/buildbot-host/buildmaster/Dockerfile
+++ b/buildbot-host/buildmaster/Dockerfile
@@ -1,5 +1,5 @@
 ARG MY_NAME="buildmaster"
-ARG MY_VERSION="v2.7.2"
+ARG MY_VERSION="v2.7.3"
 ARG IMAGE=buildbot/buildbot-master:v3.11.9
 
 FROM $IMAGE

--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -320,6 +320,33 @@ for worker_name in worker_names:
                 },
             )
         )
+        if worker_config.get(worker_name, "enable_tclient_builds") == "true":
+            c["workers"].append(
+                worker.DockerLatentWorker(
+                    f"{worker_name}-tc",
+                    worker_config.get(worker_name, "password"),
+                    max_builds=1,
+                    notify_on_missing=notify_on_missing,
+                    properties={
+                        "persist": worker_persist,
+                    },
+                    docker_host=docker_url,
+                    followStartupLogs=True,
+                    image=image,
+                    masterFQDN=master_fqdn,
+                    volumes=[
+                        f"buildbot-worker-{worker_name}-tc:{worker_persist}",
+                        f"buildbot-worker-{worker_name}-tc-build:/build",
+                    ],
+                    hostconfig={
+                        "network_mode": docker_network,
+                        "sysctls": {"net.ipv6.conf.all.disable_ipv6": 0},
+                        "cap_add": ["NET_ADMIN"],
+                        "devices": ["/dev/net/tun:/dev/net/tun"],
+                        "mem_limit": "4g",
+                    },
+                )
+            )
     else:
         c["workers"].append(
             worker.Worker(
@@ -707,10 +734,12 @@ factory = util.BuildFactory()
 factory = openvpnAddCommonUnixStepsToBuildFactory(factory, "", clang_env)
 factory = openvpnAddUnixCompileStepsToBuildFactory(factory, "", clang_env)
 
+clang_types = ["openvpn", "clang"]
 if openvpn_run_tserver_null_tests:
     factory = openvpnAddTServerNullPreStepsToBuildFactory(factory, "", clang_env)
 if openvpn_run_tclient_tests:
     factory = openvpnAddTClientPreStepsToBuildFactory(factory, "", clang_env)
+    clang_types.append("tclient")
 
 factory = openvpnAddCheckStepsToBuildFactory(factory, "", clang_env)
 
@@ -723,7 +752,7 @@ factories.update(
         factory_name: {
             "factory": factory,
             "os": "unix",
-            "types": ["openvpn", "clang"],
+            "types": clang_types,
             "schedulers": ["openvpn_main", "openvpn_release"],
         }
     }
@@ -900,10 +929,15 @@ for factory_name, factory in factories.items():
         cp = json.loads(worker_config.get(worker_name, "openvpn3_linux_command_prefix"))
         properties["openvpn3_linux_command_prefix"] = cp
 
+        actual_worker_name = worker_name
+        if "tclient" in factory["types"]:
+            if worker_config.get(worker_name, "type") == "latent_docker":
+                actual_worker_name = f"{worker_name}-tc"
+
         c["builders"].append(
             util.BuilderConfig(
                 name=builder_name,
-                workernames=[worker_name],
+                workernames=[actual_worker_name],
                 factory=factory["factory"],
                 properties=properties,
                 locks=locks,


### PR DESCRIPTION
…builders

This makes sure that the long-running t_client builds do not block all other builds.
For now only apply to the latent workers since there we can do it automatically. For static workers the worker admin will need to configure this.