### PR TITLE
buildmaster: Delete meson _builddir between builds for openvpn3-linux

### DIFF
--- a/buildbot-host/buildmaster/openvpn3-linux/common_linux_steps.cfg
+++ b/buildbot-host/buildmaster/openvpn3-linux/common_linux_steps.cfg
@@ -34,6 +34,16 @@ def openvpn3LinuxAddCommonLinuxStepsToBuildFactory(factory, shell_env):
 
     factory.addStep(
         steps.ShellCommand(
+            command=["rm", "-fr", "_builddir"],
+            name="clean builddir",
+            description="cleaning",
+            descriptionDone="clean",
+            env=shell_env,
+        )
+    )
+
+    factory.addStep(
+        steps.ShellCommand(
             command=["meson", "setup", "--prefix=/usr", "_builddir"],
             name="configure",
             description="configuring",
@@ -45,7 +55,7 @@ def openvpn3LinuxAddCommonLinuxStepsToBuildFactory(factory, shell_env):
     factory.addStep(
         steps.ShellCommand(
             command=["meson", "compile", "-C", "_builddir", "--jobs=1"],
-            name="building",
+            name="build",
             description="building",
             descriptionDone="build",
             env=shell_env,

--- a/buildbot-host/buildmaster/openvpn3-linux/gdbuspp_steps.cfg
+++ b/buildbot-host/buildmaster/openvpn3-linux/gdbuspp_steps.cfg
@@ -5,7 +5,7 @@ def openvpn3LinuxAddGdbusppStepsToBuildFactory(factory, shell_env):
         steps.Git(
             repourl="https://codeberg.org/OpenVPN/gdbuspp.git",
             mode="incremental",
-            name="clone",
+            name="clone gdbuspp",
             description="cloning",
             descriptionDone="clone",
             descriptionSuffix="gdbuspp",
@@ -16,7 +16,7 @@ def openvpn3LinuxAddGdbusppStepsToBuildFactory(factory, shell_env):
     factory.addStep(
         steps.ShellCommand(
             command="ccache -z",
-            name="ccache reset",
+            name="ccache reset gdbuspp",
             decodeRC={0: SUCCESS, 127: WARNINGS},
             description="resetting stats",
             descriptionDone="reset stats",
@@ -26,8 +26,19 @@ def openvpn3LinuxAddGdbusppStepsToBuildFactory(factory, shell_env):
 
     factory.addStep(
         steps.ShellCommand(
+            command=["rm", "-fr", "_builddir"],
+            name="clean gdbuspp builddir",
+            description="cleaning",
+            descriptionDone="clean",
+            descriptionSuffix="gdbuspp",
+            env=shell_env,
+        )
+    )
+
+    factory.addStep(
+        steps.ShellCommand(
             command=["meson", "setup", "--prefix=/usr", "_builddir"],
-            name="configure",
+            name="configure gdbuspp",
             description="configuring",
             descriptionDone="configure",
             descriptionSuffix="gdbuspp",
@@ -40,7 +51,7 @@ def openvpn3LinuxAddGdbusppStepsToBuildFactory(factory, shell_env):
     factory.addStep(
         steps.ShellCommand(
             command=["meson", "compile", "-C", "_builddir", "--jobs=1"],
-            name="building",
+            name="build gdbuspp",
             description="building",
             descriptionDone="build",
             descriptionSuffix="gdbuspp",
@@ -53,7 +64,7 @@ def openvpn3LinuxAddGdbusppStepsToBuildFactory(factory, shell_env):
     factory.addStep(
         steps.ShellCommand(
             command=["meson", "install", "-C", "_builddir"],
-            name="installing",
+            name="install gdbuspp",
             description="installing",
             descriptionDone="install",
             descriptionSuffix="gdbuspp",
@@ -65,7 +76,7 @@ def openvpn3LinuxAddGdbusppStepsToBuildFactory(factory, shell_env):
         steps.ShellCommand(
             command="ccache -s",
             decodeRC={0: SUCCESS, 127: WARNINGS},
-            name="ccache show",
+            name="ccache show gdbuspp",
             description="showing stats",
             descriptionDone="show stats",
             env=shell_env,


### PR DESCRIPTION
We could also try "setup --reconfigure", but let's go for the clean solution.