### PR TITLE
openvpn: Do not include Windows clang builds in -release scheduler

### DIFF
--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -711,6 +711,9 @@ if openvpn_run_windows_builds:
     for win_arch in ["amd64", "x86", "arm64", "amd64-clang", "x86-clang"]:
         factory = util.BuildFactory()
         run_tests = "arm64" not in win_arch
+        win_schedulers = ["openvpn_main", "openvpn_release"]
+        if "clang" in win_arch:
+            win_schedulers = ["openvpn_main"]
         factory = openvpnAddCommonWindowsStepsToBuildFactory(
             factory, f"win-{win_arch}-release", run_tests, vcpkg_env
         )
@@ -721,7 +724,7 @@ if openvpn_run_windows_builds:
                     "factory": factory,
                     "os": "windows",
                     "types": ["openvpn", "msbuild"],
-                    "schedulers": ["openvpn_main", "openvpn_release"],
+                    "schedulers": win_schedulers,
                 }
             }
         )


### PR DESCRIPTION
We do not have that support in CMake in release/2.6