### PR TITLE
openSUSE: Explicitly install "which"

### DIFF
--- a/buildbot-host/scripts/install-openvpn-build-deps-opensuse-leap.sh
+++ b/buildbot-host/scripts/install-openvpn-build-deps-opensuse-leap.sh
@@ -51,6 +51,7 @@ python3-setuptools \
 python3-wheel \
 systemd-devel \
 tinyxml2-devel \
+which \
 xxhash-devel
 
 # Hack to ensure that kernel headers can be found from a predictable place


### PR DESCRIPTION
We definitely need it for t_client.sh. And it
is not installed implicitly anymore.