### PR TITLE
buildbot-host: Switch Docker workers to use virtualenv for buildbot

### DIFF
--- a/buildbot-host/buildbot-worker-alpine-3/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-alpine-3/Dockerfile.base
@@ -2,4 +2,3 @@ ARG IMAGE=alpine:3.22.2
 ARG DEPS_SH=install-openvpn-build-deps-alpine.sh
 ARG MY_NAME="buildbot-worker-alpine-3"
 ARG MY_VERSION="v1.2.0"
-ARG PIP_INSTALL_OPTS="--break-system-packages"

--- a/buildbot-host/buildbot-worker-arch/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-arch/Dockerfile.base
@@ -1,5 +1,4 @@
 ARG IMAGE=docker.io/library/archlinux:latest
 ARG DEPS_SH=install-openvpn-build-deps-arch.sh
 ARG MY_NAME="buildbot-worker-arch"
-ARG PIP_INSTALL_OPTS="--break-system-packages"
 ARG MY_VERSION="v1.1.0"

--- a/buildbot-host/buildbot-worker-debian-12-openvpn-legacy/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-debian-12-openvpn-legacy/Dockerfile.base
@@ -1,5 +1,4 @@
 ARG IMAGE=debian:12
 ARG DEPS_SH=install-openvpn-build-deps-ubuntu.sh
 ARG MY_NAME="buildbot-worker-debian-12-openvpn-legacy"
-ARG PIP_INSTALL_OPTS="--break-system-packages"
 ARG MY_VERSION="v1.0.0"

--- a/buildbot-host/buildbot-worker-debian-12/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-debian-12/Dockerfile.base
@@ -1,5 +1,4 @@
 ARG IMAGE=debian:12
 ARG DEPS_SH=install-openvpn-build-deps-ubuntu.sh
 ARG MY_NAME="buildbot-worker-debian-12"
-ARG PIP_INSTALL_OPTS="--break-system-packages"
 ARG MY_VERSION="v1.1.0"

--- a/buildbot-host/buildbot-worker-debian-13/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-debian-13/Dockerfile.base
@@ -1,5 +1,4 @@
 ARG IMAGE=debian:trixie
 ARG DEPS_SH=install-openvpn-build-deps-ubuntu.sh
 ARG MY_NAME="buildbot-worker-debian-13"
-ARG PIP_INSTALL_OPTS="--break-system-packages"
 ARG MY_VERSION="v1.0.0"

--- a/buildbot-host/buildbot-worker-debian-9/Dockerfile
+++ b/buildbot-host/buildbot-worker-debian-9/Dockerfile
@@ -76,7 +76,8 @@ python3-pip \
 python3-roman \
 python3-setuptools \
 python3-wheel \
-uuid-dev
+uuid-dev \
+virtualenv
 
 RUN rm -rf /var/lib/apt/lists/*
 
@@ -89,6 +90,7 @@ RUN set -ex; \
     rm -f /buildbot/install-buildbot.sh
 
 COPY buildbot.tac /buildbot/
+COPY start_agent.sh /buildbot/
 RUN mkdir -p /home/buildbot
 
-CMD ["twistd", "--pidfile=", "--nodaemon", "--python=buildbot.tac"]
+CMD ["/buildbot/start_agent.sh"]

--- a/buildbot-host/buildbot-worker-debian-unstable/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-debian-unstable/Dockerfile.base
@@ -1,5 +1,4 @@
 ARG IMAGE=debian:unstable
 ARG DEPS_SH=install-openvpn-build-deps-ubuntu.sh
 ARG MY_NAME="buildbot-worker-debian-unstable"
-ARG PIP_INSTALL_OPTS="--break-system-packages"
 ARG MY_VERSION="v1.1.0"

--- a/buildbot-host/buildbot-worker-ubuntu-2404/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-ubuntu-2404/Dockerfile.base
@@ -1,7 +1,6 @@
 ARG IMAGE=ubuntu:24.04
 ARG DEPS_SH=install-openvpn-build-deps-ubuntu.sh
 ARG MY_NAME="buildbot-worker-ubuntu-2404"
-ARG PIP_INSTALL_OPTS="--break-system-packages"
 ARG INSTALL_MINGW=true
 ARG INSTALL_ANDROID_NDK=true
 ARG MY_VERSION="v1.2.0"

--- a/buildbot-host/buildbot-worker-ubuntu-2510/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-ubuntu-2510/Dockerfile.base
@@ -1,5 +1,4 @@
 ARG IMAGE=ubuntu:25.10
 ARG DEPS_SH=install-openvpn-build-deps-ubuntu.sh
 ARG MY_NAME="buildbot-worker-ubuntu-2510"
-ARG PIP_INSTALL_OPTS="--break-system-packages"
 ARG MY_VERSION="v1.0.0"

--- a/buildbot-host/launch.sh
+++ b/buildbot-host/launch.sh
@@ -17,8 +17,10 @@ if [ "$1" = "" ]; then
 fi
 
 # Get image name and version
-IMAGE=`grep MY_NAME $DIR/Dockerfile.base|awk 'BEGIN { FS = "\"" }; { print $2 }'`
-TAG=`grep MY_VERSION $DIR/Dockerfile.base|awk 'BEGIN { FS = "\"" }; { print $2 }'`
+DOCKERFILE=$DIR/Dockerfile.base
+[ ! -f $DIR/Dockerfile ] || DOCKERFILE=$DIR/Dockerfile
+IMAGE=`grep MY_NAME $DOCKERFILE|awk 'BEGIN { FS = "\"" }; { print $2 }'`
+TAG=`grep MY_VERSION $DOCKERFILE|awk 'BEGIN { FS = "\"" }; { print $2 }'`
 
 docker container stop $IMAGE
 docker container rm $IMAGE

--- a/buildbot-host/scripts/install-buildbot.sh
+++ b/buildbot-host/scripts/install-buildbot.sh
@@ -6,14 +6,15 @@ set -ex
 
 BUILDBOT_VERSION=${BUILDBOT_VERSION:-4.3.0}
 
-# Upgrading pip may or may not work. On Ubuntu 24.04 it may fail with
-#
-# "ERROR: Cannot uninstall pip 24.0, RECORD file not found. Hint: The package was installed by debian."
-#
-# Try and if it fails just keep on going
-#
-pip3 install $PIP_INSTALL_OPTS --upgrade pip || true
-pip --no-cache-dir install $PIP_INSTALL_OPTS twisted[tls]
-pip --no-cache-dir install $PIP_INSTALL_OPTS buildbot_worker==$BUILDBOT_VERSION
+virtualenv /buildbot_venv --python=python3
+ . /buildbot_venv/bin/activate
+
+pip install --upgrade pip
+pip --no-cache-dir install twisted[tls]
+pip --no-cache-dir install buildbot_worker==$BUILDBOT_VERSION
+
+# not directly related to buildbot, but we want to install it
+# into the venv, so easiests to put it here.
+pip --no-cache-dir install pre-commit
 
 useradd --create-home --home-dir=/var/lib/buildbot buildbot

--- a/buildbot-host/scripts/install-openvpn-build-deps-alpine.sh
+++ b/buildbot-host/scripts/install-openvpn-build-deps-alpine.sh
@@ -49,6 +49,7 @@ py3-docutils \
 py3-pip \
 py3-roman \
 py3-setuptools \
+py3-virtualenv \
 py3-wheel \
 shadow \
 tinyxml2-dev

--- a/buildbot-host/scripts/install-openvpn-build-deps-arch.sh
+++ b/buildbot-host/scripts/install-openvpn-build-deps-arch.sh
@@ -48,6 +48,7 @@ python \
 python-gobject \
 python-pip \
 python-setuptools \
+python-virtualenv \
 python-wheel \
 tinyxml2 \
 which \

--- a/buildbot-host/scripts/install-openvpn-build-deps-fedora.sh
+++ b/buildbot-host/scripts/install-openvpn-build-deps-fedora.sh
@@ -57,6 +57,7 @@ python3-wheel \
 selinux-policy-devel \
 systemd-devel \
 tinyxml2-devel \
+virtualenv \
 which \
 xxhash-devel \
 zlib-devel

--- a/buildbot-host/scripts/install-openvpn-build-deps-opensuse-leap.sh
+++ b/buildbot-host/scripts/install-openvpn-build-deps-opensuse-leap.sh
@@ -49,6 +49,7 @@ python3-Jinja2 \
 python3-pip \
 python3-pyOpenSSL \
 python3-setuptools \
+python3-virtualenv \
 python3-wheel \
 systemd-devel \
 tinyxml2-devel \

--- a/buildbot-host/scripts/install-openvpn-build-deps-ubuntu.sh
+++ b/buildbot-host/scripts/install-openvpn-build-deps-ubuntu.sh
@@ -82,7 +82,8 @@ python3-setuptools \
 python3-wheel \
 softhsm2 \
 uncrustify \
-uuid-dev
+uuid-dev \
+virtualenv
 
 NEED_VCPKG=false
 IS_X86_64=false
@@ -144,8 +145,6 @@ $APT_INSTALL policykit-1 || $APT_INSTALL polkitd pkexec
 # -generic is the Ubuntu variant, -amd64 the Debian variant.
 # We just try both.
 $APT_INSTALL linux-headers-generic || $APT_INSTALL linux-headers-amd64
-
-pip3 --no-cache-dir install ${PIP_INSTALL_OPTS:-} pre-commit
 
 # Hack to ensure that kernel headers can be found from a predictable place
 ln -s /lib/modules/$(ls /lib/modules|head -n 1)/build /buildbot/kernel-headers

--- a/buildbot-host/snippets/Dockerfile.common
+++ b/buildbot-host/snippets/Dockerfile.common
@@ -11,7 +11,6 @@ RUN mkdir -p /buildbot
 ARG DEPS_SH
 ARG INSTALL_MINGW
 ARG INSTALL_ANDROID_NDK
-ARG PIP_INSTALL_OPTS
 COPY scripts/${DEPS_SH} /buildbot/
 RUN set -ex; \
     /buildbot/${DEPS_SH}; \
@@ -30,6 +29,7 @@ RUN set -ex; \
     rm -f /buildbot/install-lwipovpn.sh
 
 COPY buildbot.tac /buildbot/
+COPY start_agent.sh /buildbot/
 RUN mkdir -p /home/buildbot
 
-CMD ["twistd", "--pidfile=", "--nodaemon", "--python=buildbot.tac"]
+CMD ["/buildbot/start_agent.sh"]

--- a/buildbot-host/start_agent.sh
+++ b/buildbot-host/start_agent.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+. /buildbot_venv/bin/activate
+exec twistd --pidfile= --nodaemon --python=buildbot.tac


### PR DESCRIPTION
We now accumulated multiple work-arounds for problems when package-installed python modules conflict with pip-installed modules. Since I ran into another
instance of this, let's finally invest the time
to switch to virtualenv instead.