### PR TITLE
buildbot: Switch from CA/Key/Cert to inline file for t_client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@ worker.ini
 .vagrant
 *.pfx
 build.log
-t_client.crt
-t_client.key
+t_client.inline

--- a/buildbot-host/create-t_client-certs.sh
+++ b/buildbot-host/create-t_client-certs.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Create t_client certs for all workers
+#
+
+set -eux
+
+: ${BUILDBOT_HOST_DIR:=.}
+: ${HOSTNAME:=$(hostname --short)}
+: ${SSH_USER:=$USER}
+: ${CERT_ALG:=ec}
+PREFIX="buildbot-worker"
+
+for worker in $(ls -d1 "${BUILDBOT_HOST_DIR}/$PREFIX-"*)
+do
+  WORKERNAME=$(basename $worker)
+
+  ssh -l $SSH_USER -p 774 phillip.secure-computing.net /root/generate-client-cert "$CERT_ALG" "${HOSTNAME}-${WORKERNAME}" >$worker/t_client.inline
+  chmod 660 $worker/t_client.inline
+done

--- a/buildbot-host/snippets/Dockerfile.common
+++ b/buildbot-host/snippets/Dockerfile.common
@@ -19,7 +19,7 @@ RUN set -ex; \
 # Install buildbot
 ARG MY_NAME
 ARG BUILDBOT_VERSION
-COPY scripts/install-lwipovpn.sh scripts/install-buildbot.sh t_client/*.crt t_client/*.rc t_client/*.txt ${MY_NAME}/t_client.* ${MY_NAME}/t_server_null.rc /buildbot/
+COPY scripts/install-lwipovpn.sh scripts/install-buildbot.sh t_client/*.rc t_client/*.txt ${MY_NAME}/t_client.* ${MY_NAME}/t_server_null.rc /buildbot/
 RUN set -ex; \
     /buildbot/install-buildbot.sh; \
     rm -f /buildbot/install-buildbot.sh

--- a/buildbot-host/t_client/t_client.rc
+++ b/buildbot-host/t_client/t_client.rc
@@ -10,9 +10,8 @@ if [ -z "$KEYBASE" ] ; then
     KEYBASE="/buildbot"
 fi
 
-CA_CERT="$KEYBASE/ca.crt"
-CLIENT_KEY="$KEYBASE/t_client.key"
-CLIENT_CERT="$KEYBASE/t_client.crt"
+CA_CERT=1
+INLINE_FILE="$KEYBASE/t_client.inline"
 
 # not required in docker
 #RUN_SUDO=sudo
@@ -79,8 +78,7 @@ fi
 #
 # base confic that is the same for all the p2mp test runs
 #
-OPENVPN_BASE_P2MP="--client --tls-cert-profile insecure --ca $CA_CERT \
-	--cert $CLIENT_CERT --key $CLIENT_KEY \
+OPENVPN_BASE_P2MP="--client --config $INLINE_FILE \
 	--remote-cert-tls server --verb 3 $COMP_ARGS $OPENVPN_EXTRA_CF"
 
 # base config for p2p tests


### PR DESCRIPTION
New CA is powered by easyrsa v3, so we can simplify our setup a bit.