### PR TITLE
scripts: Use Java 21 for Jenkins agents

### DIFF
--- a/scripts/jenkins-agent-ssh.ps1
+++ b/scripts/jenkins-agent-ssh.ps1
@@ -4,7 +4,7 @@ param ([string] $workdir)
 
 Write-Host "Setting up Jenkins agent (SSH)"
 
-& choco.exe install -y openjdk17
+& choco.exe install -y microsoft-openjdk-21
 CheckLastExitCode
 
 if (-Not (Test-Path $workdir)) {

--- a/scripts/jenkins-agent.ps1
+++ b/scripts/jenkins-agent.ps1
@@ -8,7 +8,7 @@ param ([string] $workdir,
 
 Write-Host "Setting up Jenkins agent"
 
-& choco.exe install -y openjdk17
+& choco.exe install -y microsoft-openjdk-21
 CheckLastExitCode
 
 if (-Not (Test-Path $workdir)) {


### PR DESCRIPTION
Java 17 is not supported anymore in latest Jenkins LTS release.