### PR TITLE
buildmaster: Add tserver worker and steps

### DIFF
--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -916,6 +916,7 @@ for steps_file in [
     "unix_compile_steps.cfg",
     "unix_unit-test_steps.cfg",
     "code_check.cfg",
+    "t_server_steps.cfg",
 ]:
     exec(
         compile(
@@ -1109,6 +1110,22 @@ for combo in packaging_config_opt_combos:
         }
     )
     del factory
+
+# OpenVPN 2 t_server tests
+factory = util.BuildFactory()
+factory = openvpnAddTServerStepsToBuildFactory(factory)
+factory_name = getFactoryName("-tserver")
+factories.update(
+    {
+        factory_name: {
+            "factory": factory,
+            "os": "unix",
+            "types": ["tserver"],
+            "schedulers": [],
+        }
+    }
+)
+del factory
 
 # OpenVPN 2 Windows msbuild tests
 if openvpn_run_windows_builds:
@@ -1343,6 +1360,7 @@ for factory_name, factory in factories.items():
             "clang",
             "compile",
             "tclient",
+            "tserver",
             "ovpn-dco",
             "ovpn-dco-smoketest",
             "code-check",
@@ -1576,6 +1594,24 @@ for branch_type, branch_name in openvpn_branches.items():
             openvpn_gerrit_full_scheduler.name,
         ],
     )
+
+tserver_force_scheduler = schedulers.ForceScheduler(
+    name=f"openvpn-force-tserver",
+    builderNames=["t-server-factory-tserver"],
+    codebases=[
+        util.CodebaseParameter(
+            "",
+            label="Commit",
+            branch=util.StringParameter(name="branch", default="master"),
+            revision=util.StringParameter(name="revision", default=""),
+            repository=util.StringParameter(
+                name="repository", default=openvpn_repo_url
+            ),
+            project=util.FixedParameter(name="project", default="openvpn"),
+        ),
+    ],
+)
+c["schedulers"].append(tserver_force_scheduler)
 
 openvpn3_smoketest_scheduler = schedulers.SingleBranchScheduler(
     name="openvpn3-smoketest",

--- a/buildbot-host/buildmaster/openvpn/t_server_steps.cfg
+++ b/buildbot-host/buildmaster/openvpn/t_server_steps.cfg
@@ -1,0 +1,26 @@
+# -*- python -*-
+# ex: set filetype=python:
+def openvpnAddTServerStepsToBuildFactory(factory):
+    factory.addStep(
+        steps.Git(
+            repourl=util.Interpolate("%(prop:repository)s"),
+            mode="incremental",
+            origin="buildbot",
+            name="openvpn clone",
+            description="cloning",
+            descriptionDone="clone",
+            workdir="/home/rocky/openvpn",
+        )
+    )
+
+    factory.addStep(
+        steps.ShellCommand(
+            command=["./t_server.sh", "nogit"],
+            name="run t_server",
+            description="testing",
+            descriptionDone="test",
+            workdir="/home/rocky/openvpn-tests/t_server/original",
+        )
+    )
+
+    return factory

--- a/buildbot-host/buildmaster/worker-default.ini
+++ b/buildbot-host/buildmaster/worker-default.ini
@@ -17,6 +17,7 @@ enable_clang_builds=false
 enable_cmake_builds=false
 enable_android_builds=false
 enable_compile_builds=true
+enable_tserver_builds=false
 enable_tclient_builds=true
 # Note: only affects static workers, ignored for latent ones
 enable_separate_tclient_worker=false


### PR DESCRIPTION
For now we only add this as a force scheduler.
The tests run very long and it is unclear whether
we want to trigger them automatically at all.