### PR TITLE
master.cfg: Move tserver to normal branch builds

### DIFF
--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -1121,7 +1121,7 @@ factories.update(
             "factory": factory,
             "os": "unix",
             "types": ["tserver"],
-            "schedulers": [],
+            "schedulers": ["openvpn_main", "openvpn_release27"],
         }
     }
 )
@@ -1594,24 +1594,6 @@ for branch_type, branch_name in openvpn_branches.items():
             openvpn_gerrit_full_scheduler.name,
         ],
     )
-
-tserver_force_scheduler = schedulers.ForceScheduler(
-    name=f"openvpn-force-tserver",
-    builderNames=["t-server-factory-tserver"],
-    codebases=[
-        util.CodebaseParameter(
-            "",
-            label="Commit",
-            branch=util.StringParameter(name="branch", default="master"),
-            revision=util.StringParameter(name="revision", default=""),
-            repository=util.StringParameter(
-                name="repository", default=openvpn_repo_url
-            ),
-            project=util.FixedParameter(name="project", default="openvpn"),
-        ),
-    ],
-)
-c["schedulers"].append(tserver_force_scheduler)
 
 openvpn3_smoketest_scheduler = schedulers.SingleBranchScheduler(
     name="openvpn3-smoketest",


### PR DESCRIPTION
That will also automatically add the appropriate
force schedulers, so remove the custom one.